### PR TITLE
Fixed bower.json that wasn't passing bower validation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,20 @@
 {
   "name": "jwt-decode",
+  "description": "Decode JWT payload in the browser",
   "version": "1.0.0",
+  "keywords": ["jwt", "jsonwebtoken", "token", "decode"],
+  "homepage": "https://github.com/auth0/jwt-decode",
   "main": "build/jwt-decode.js",
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {},
+  "license": ["MIT"],
+  "ignore": [
+    "*/.*",
+    "*.json",
+    "src",
+    "*.yml",
+    "Gemfile",
+    "Gemfile.lock",
+    "*.md"
+  ]
 }


### PR DESCRIPTION
Latest change set on master needs to be tagged as 1.0.0 so I can use versioning in my application's bower.json correctly :)

You can verify changes work correctly on bower (I set up a temporary package: jwt-decode-test - I'll take this package down once we get this fixed up). 