### PR TITLE
Avoid use of window in parsing JSON

### DIFF
--- a/lib/json_parse.js
+++ b/lib/json_parse.js
@@ -1,3 +1,9 @@
 module.exports = function (str) {
-  return window.JSON ? window.JSON.parse(str) : eval('(' + str + ')');
+  var parsed;
+  if (typeof JSON === 'object') {
+    parsed = JSON.parse(str);
+  } else {
+    parsed = eval('(' + str + ')');
+  }
+  return parsed;
 };


### PR DESCRIPTION
This uses `JSON.parse()` if `JSON` is defined.  Otherwise, it uses `eval`.

Fixes #5.
