### PR TITLE
Fix NPM Repository link

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/auth0/jwt-decode.js"
+    "url": "git://github.com/auth0/jwt-decode"
   },
   "author": "Jose F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "license": "MIT",


### PR DESCRIPTION
The link to the GitHub repo was broken on NPM, this fixes that.