### PR TITLE
(fixes #29) IE: Invalid calling object

### DIFF
--- a/lib/atob.js
+++ b/lib/atob.js
@@ -35,4 +35,4 @@ function polyfill (input) {
 }
 
 
-module.exports = typeof window !== 'undefined' && window.atob || polyfill;
+module.exports = typeof window !== 'undefined' && window.atob && window.atob.bind(window) || polyfill;


### PR DESCRIPTION
Thanks to @brianleipprandt for figuring out the problem. This pull request is a slight improvement that fixes issues with browsers that do not have atob (such as IE9).