### PR TITLE
Fix Auth0 link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
The link to the Auth0 site was trying to access `auth0.com` relatively from the README file, so I added the `https://` prefix.