### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jwt-decode",
   "description": "Decode JWT payload in the browser",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "keywords": ["jwt", "jsonwebtoken", "token", "decode"],
   "homepage": "https://github.com/auth0/jwt-decode",
   "main": "build/jwt-decode.js",


### PR DESCRIPTION
The current release is 2.1.0. package.json is up-to-date. I think bower.json should be as well.