### PR TITLE
Corrected LICENSE file link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](LICENSE.txt) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
 
 [browserify]: http://browserify.org
 [webpack]: http://webpack.github.io/


### PR DESCRIPTION
This was incorrectly linked from the NPM page and the repository home.