### PR TITLE
Mentioned InvalidTokenError in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ console.log(decoded);
 
 ~~~
 
-**Note:** A falsy token will throw an error.
+**Note:** A falsy or malformed token will throw an `InvalidTokenError` error.
 
 Can also be used with [browserify] or [webpack] by doing `npm install jwt-decode` and requiring:
 


### PR DESCRIPTION
### Description

- Added to the README a reference to the error thrown when the token is falsy or malformed.

### References

- Closes https://github.com/auth0/jwt-decode/issues/83

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
