### PR TITLE
Added more instructions on how to script include this.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ var jwtDecode = require('jwt-decode');
 
 Can also be installed and used with [Polymer-based wrapper](https://github.com/firmfirm/f-jwt-decode).
 
+## Include with a script tag
+
+Copy the file jwt-decode.min.js from the build/ folder to your project somewhere, then include like so:
+
+~~~html
+<script src="jwt-decode.min.js"></script>
+~~~
+
 ## Develop
 
 Run `grunt dev` and fire a browser at http://localhost:9999/test_harness.html.


### PR DESCRIPTION
Yeah I missed that there was a minified version, and I guesstimate that others might like to copy pasta this library into use in their projects cos it's great.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
