### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 **Warning: When upgrading from version `2` to `3`, there's a potentially breaking change**
 
+
 If you've previously imported the library as `import * as jwt_decode from 'jwt-decode'`, you'll have to change your import to `import jwt_decode from 'jwt-decode';`.
 
 ---
@@ -49,7 +50,7 @@ console.log(decodedHeader);
 ## Use as a CommonJS package
 
 ```javascript
-const jwt_decode = require('jwt-decode');
+const jwt_decode = require('jwt-decode').default;
 ...
 ```
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Our cypress tests broke after upgrading JWT to use the newest version (3.0). 
The issue was to do with the "changes" in the library is imported.

I have changed the Readme, so that if people look for example of using this library with Require, they will find the correct documentation


### References

https://stackoverflow.com/questions/43247696/javascript-require-vs-require-default

### Testing

i have tested out application after the change both manually and by running E2E with cypress and everything worked after applying the change above

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
