### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Copy the file `jwt-decode.js` from the `build/` folder to your project somewhere
 <script src="jwt-decode.js"></script>
 ```
 
-## Older verions
+## Older versions
 
 If you want to use the library trough Bower, an HTML import, use [version `v2.2.0`](https://github.com/auth0/jwt-decode/tree/v2.2.0). It has the same functionality.
 

--- a/lib/index.standalone.js
+++ b/lib/index.standalone.js
@@ -3,7 +3,7 @@
  */
 import jwtDecode from "./index";
 
-//use amd or just through to window object.
+//use amd or just through the window object.
 if (window) {
     if (typeof window.define == "function" && window.define.amd) {
         window.define("jwt_decode", function() {

--- a/lib/index.standalone.js
+++ b/lib/index.standalone.js
@@ -3,7 +3,7 @@
  */
 import jwtDecode from "./index";
 
-//use amd or just throught to window object.
+//use amd or just through to window object.
 if (window) {
     if (typeof window.define == "function" && window.define.amd) {
         window.define("jwt_decode", function() {


### PR DESCRIPTION
### Description

This pull request addresses two minor typos — one in the library and one in the README file. This has minimal impact on the user, but by fixing these the repository positions itself to maintain the trust of its users by ensuring that it presents a well-curated experience free of common typographic or grammatical mistakes.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
