### PR TITLE
Add cjs compatibility with default export

### DIFF
--- a/lib/index.cjs.js
+++ b/lib/index.cjs.js
@@ -1,5 +1,6 @@
 import jwtDecode, { InvalidTokenError } from "./index";
 
 const wrapper = jwtDecode;
+wrapper.default = jwtDecode;
 wrapper.InvalidTokenError = InvalidTokenError;
 export default wrapper;


### PR DESCRIPTION
### Description

This allows to use the ESM default import syntax in environments where the import resolves to the CJS build.

This allows to create type definitions that work with both ESM and CJS environments.

This uses solution D of #103, because this is the only non-breaking way to resolve this.

### References

#90 #91 (comments)

Closes #96 (This was wrongfully closed)
Closes #97 (This was wrongfully closed)
Closes #102 (This was wrongfully closed)
Closes #103

### Testing

This can’t really be tested on its own. This will allow to create valid TypeScript type definitions.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
