### PR TITLE
Add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+export class InvalidTokenError extends Error {}
+
+export interface JwtDecodeOptions {
+  header?: boolean;
+}
+
+export default function jwtDecode(token: string, options?: JwtDecodeOptions): unknown;

--- a/lib/index.cjs.js
+++ b/lib/index.cjs.js
@@ -1,5 +1,6 @@
 import jwtDecode, { InvalidTokenError } from "./index";
 
 const wrapper = jwtDecode;
+wrapper.default = jwtDecode;
 wrapper.InvalidTokenError = InvalidTokenError;
 export default wrapper;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Decode JWT tokens, mostly useful for browser applications.",
     "main": "build/jwt-decode.cjs.js",
     "module": "build/jwt-decode.esm.js",
+    "types": "index.d.ts",
     "keywords": [
         "jwt",
         "browser"


### PR DESCRIPTION
### Description

This adds TypeScript type definitions based on #104.

If this isn’t desired, I’ll gladly add these to DefinitelyTyped instead once #104 is merged and released.

### References

#103
#104

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
