### PR TITLE
Make return type generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,4 +4,4 @@ export interface JwtDecodeOptions {
   header?: boolean;
 }
 
-export default function jwtDecode(token: string, options?: JwtDecodeOptions): unknown;
+export default function jwtDecode<T>(token: string, options?: JwtDecodeOptions): T;


### PR DESCRIPTION
### Description

This allows to use the function as:

```ts
const payload = jwtDecode<MyJwtPayload>(token);
```

in addition to the current behaviour:

```ts
const payload = jwtDecode(token) as MyJwtPayload;
```

Closes #109

### References

- #105
- #107
- #109

### Testing

Create a file named `foo.ts` in the repository root with the following content:

```ts
import jwtDecode from '.';

const result = jwtDecode('foo');
```

Observe the type of `result` is still `unknown`. Now change it to:

```ts
import jwtDecode from '.';

const result = jwtDecode<number>('foo');
```

Observe the type of `result` is now `number`.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
