### PR TITLE
fix(typing): changed JwtHeader type to typ

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export interface JwtDecodeOptions {
 }
 
 export interface JwtHeader {
-  type?: string;
+  typ?: string;
   alg?: string;
 }
 


### PR DESCRIPTION
Hello there,

I am using your library in a VueJS project using Typescript. Unfortunately I found a typing issue in the `JwtHeader` interface located in the `index.d.ts` file.

Currently there is a `type` header field, which should be called `typ` (see here https://tools.ietf.org/html/rfc7519#section-5.1).

Kind regards,
Lukas