### PR TITLE
make token parameter type unknown

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,6 @@ export interface JwtPayload {
 }
 
 export default function jwtDecode<T = unknown>(
-  token: string,
+  token: unknown,
   options?: JwtDecodeOptions
 ): T;


### PR DESCRIPTION
### Description

The jwtDecode function will throw an `InvalidTokenError` when the token
parameter is not a string, so since this is part of the api, the type of
the token should not be limited to just string.

Let me know if this seems reasonable or if there is anything I should change

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
