### PR TITLE
fix: correct stack trace for "InvalidTokenError"

### DIFF
--- a/build/jwt-decode.js
+++ b/build/jwt-decode.js
@@ -1,7 +1,7 @@
 (function (factory) {
     typeof define === 'function' && define.amd ? define(factory) :
     factory();
-}((function () { 'use strict';
+})((function () { 'use strict';
 
     /**
      * The code was extracted from:
@@ -83,9 +83,14 @@
         }
     }
 
-    class InvalidTokenError extends Error {
-        name = "InvalidTokenError";
+    function InvalidTokenError(message) {
+        var _this = Error.apply(this, arguments) || this;
+        _this.name = "InvalidTokenError";
+        _this.message = message;
+        return _this;
     }
+
+    InvalidTokenError.prototype = new Error();
 
     function jwtDecode(token, options) {
         if (typeof token !== "string") {
@@ -116,5 +121,5 @@
         }
     }
 
-})));
+}));
 //# sourceMappingURL=jwt-decode.js.map

--- a/build/jwt-decode.js
+++ b/build/jwt-decode.js
@@ -91,6 +91,7 @@
     }
 
     InvalidTokenError.prototype = new Error();
+    InvalidTokenError.prototype.name = "InvalidTokenError";
 
     function jwtDecode(token, options) {
         if (typeof token !== "string") {

--- a/build/jwt-decode.js
+++ b/build/jwt-decode.js
@@ -83,12 +83,9 @@
         }
     }
 
-    function InvalidTokenError(message) {
-        this.message = message;
+    class InvalidTokenError extends Error {
+        name = "InvalidTokenError";
     }
-
-    InvalidTokenError.prototype = new Error();
-    InvalidTokenError.prototype.name = "InvalidTokenError";
 
     function jwtDecode(token, options) {
         if (typeof token !== "string") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,9 +2,14 @@
 
 import base64_url_decode from "./base64_url_decode";
 
-export class InvalidTokenError extends Error {
-    name = "InvalidTokenError";
+export function InvalidTokenError(message) {
+    var _this = Error.apply(this, arguments) || this;
+    _this.name = "InvalidTokenError";
+    _this.message = message;
+    return _this;
 }
+
+InvalidTokenError.prototype = new Error();
 
 export default function(token, options) {
     if (typeof token !== "string") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,12 +2,9 @@
 
 import base64_url_decode from "./base64_url_decode";
 
-export function InvalidTokenError(message) {
-    this.message = message;
+export class InvalidTokenError extends Error {
+    name = "InvalidTokenError";
 }
-
-InvalidTokenError.prototype = new Error();
-InvalidTokenError.prototype.name = "InvalidTokenError";
 
 export default function(token, options) {
     if (typeof token !== "string") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ export function InvalidTokenError(message) {
 }
 
 InvalidTokenError.prototype = new Error();
+InvalidTokenError.prototype.name = "InvalidTokenError";
 
 export default function(token, options) {
     if (typeof token !== "string") {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The current way you create an error destroy any stack trace back to caller code.

Test file

```js
// file.js
const decode = require('./');

decode('foobar');
```

`master`:

```
Error [InvalidTokenError]
    at Object.<anonymous> (/Users/simen/repos/jwt-decode/build/jwt-decode.cjs.js:1:1147)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.<anonymous> (/Users/simen/repos/jwt-decode/file.js:1:16)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10) {
  message: "Invalid token specified: Cannot read property 'replace' of undefined"
}
```

(notice no `file.js` in stack trace)

This branch:

```
[InvalidTokenError]: Invalid token specified: Cannot read property 'replace' of undefined
    at o (/Users/simen/repos/jwt-decode/build/jwt-decode.cjs.js:1:1107)
    at Object.<anonymous> (/Users/simen/repos/jwt-decode/file.js:3:1)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47
```

Notice that the `message` field is also lost with your current approach

### Testing

See above

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
