### PR TITLE
Add support for node hybrid cjs and esm modules

### DIFF
--- a/build/jwt-decode.js
+++ b/build/jwt-decode.js
@@ -1,7 +1,7 @@
 (function (factory) {
     typeof define === 'function' && define.amd ? define(factory) :
     factory();
-}((function () { 'use strict';
+})((function () { 'use strict';
 
     /**
      * The code was extracted from:
@@ -119,5 +119,5 @@
         }
     }
 
-})));
+}));
 //# sourceMappingURL=jwt-decode.js.map

--- a/common.d.ts
+++ b/common.d.ts
@@ -1,0 +1,20 @@
+export class InvalidTokenError extends Error {}
+
+export interface JwtDecodeOptions {
+  header?: boolean;
+}
+
+export interface JwtHeader {
+  typ?: string;
+  alg?: string;
+}
+
+export interface JwtPayload {
+  iss?: string;
+  sub?: string;
+  aud?: string[] | string;
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+  jti?: string;
+}

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,0 +1,27 @@
+export class InvalidTokenError extends Error {}
+
+export interface JwtDecodeOptions {
+  header?: boolean;
+}
+
+export interface JwtHeader {
+  typ?: string;
+  alg?: string;
+}
+
+export interface JwtPayload {
+  iss?: string;
+  sub?: string;
+  aud?: string[] | string;
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+  jti?: string;
+}
+
+declare function jwtDecode<T = unknown>(
+  token: string,
+  options?: JwtDecodeOptions
+): T
+
+export default jwtDecode;

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,23 +1,5 @@
-export class InvalidTokenError extends Error {}
-
-export interface JwtDecodeOptions {
-  header?: boolean;
-}
-
-export interface JwtHeader {
-  typ?: string;
-  alg?: string;
-}
-
-export interface JwtPayload {
-  iss?: string;
-  sub?: string;
-  aud?: string[] | string;
-  exp?: number;
-  nbf?: number;
-  iat?: number;
-  jti?: string;
-}
+import { JwtDecodeOptions } from "./common";
+export * from "./common";
 
 declare function jwtDecode<T = unknown>(
   token: string,

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,5 +1,5 @@
-import { JwtDecodeOptions } from "./common";
-export * from "./common";
+import { JwtDecodeOptions } from "./common.js";
+export * from "./common.js";
 
 declare function jwtDecode<T = unknown>(
   token: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
-export class InvalidTokenError extends Error {}
+declare class InvalidTokenError extends Error {}
 
-export interface JwtDecodeOptions {
+declare interface JwtDecodeOptions {
   header?: boolean;
 }
 
-export interface JwtHeader {
-  typ?: string;
+declare interface JwtHeader {
+  type?: string;
   alg?: string;
 }
 
-export interface JwtPayload {
+declare interface JwtPayload {
   iss?: string;
   sub?: string;
   aud?: string[] | string;
@@ -19,7 +19,13 @@ export interface JwtPayload {
   jti?: string;
 }
 
-export default function jwtDecode<T = unknown>(
+declare namespace jwtDecode {
+  export { InvalidTokenError, JwtDecodeOptions, JwtHeader, JwtPayload }
+}
+
+declare function jwtDecode<T = unknown>(
   token: string,
   options?: JwtDecodeOptions
 ): T;
+
+export = jwtDecode;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,4 @@
-declare class InvalidTokenError extends Error {}
-
-declare interface JwtDecodeOptions {
-  header?: boolean;
-}
-
-declare interface JwtHeader {
-  type?: string;
-  alg?: string;
-}
-
-declare interface JwtPayload {
-  iss?: string;
-  sub?: string;
-  aud?: string[] | string;
-  exp?: number;
-  nbf?: number;
-  iat?: number;
-  jti?: string;
-}
+import { InvalidTokenError, JwtDecodeOptions, JwtHeader, JwtPayload } from "./common";
 
 declare namespace jwtDecode {
   export { InvalidTokenError, JwtDecodeOptions, JwtHeader, JwtPayload }
@@ -26,6 +7,6 @@ declare namespace jwtDecode {
 declare function jwtDecode<T = unknown>(
   token: string,
   options?: JwtDecodeOptions
-): T;
+): T
 
 export = jwtDecode;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Decode JWT tokens, mostly useful for browser applications.",
     "main": "build/jwt-decode.cjs.js",
     "module": "build/jwt-decode.esm.js",
-    "types": "index.d.ts",
+    "types": "index.d.mts",
     "exports": {
         ".": {
             "types": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
     "main": "build/jwt-decode.cjs.js",
     "module": "build/jwt-decode.esm.js",
     "types": "index.d.ts",
+    "exports": {
+        ".": {
+            "require": "./build/jwt-decode.cjs.js",
+            "import": "./build/jwt-decode.mjs",
+            "default": "./build/jwt-decode.mjs"
+        },
+        "./package.json": "./package.json"
+    },
     "keywords": [
         "jwt",
         "browser"

--- a/package.json
+++ b/package.json
@@ -4,17 +4,15 @@
     "description": "Decode JWT tokens, mostly useful for browser applications.",
     "main": "build/jwt-decode.cjs.js",
     "module": "build/jwt-decode.mjs",
-    "types": "index.d.mts",
+    "types": "index.d.ts",
     "exports": {
         ".": {
             "types": {
-                "require": "./index.d.ts",
                 "import": "./index.d.mts",
-                "default": "./index.d.mts"
+                "default": "./index.d.ts"
             },
-            "require": "./build/jwt-decode.cjs.js",
             "import": "./build/jwt-decode.mjs",
-            "default": "./build/jwt-decode.mjs"
+            "default": "./build/jwt-decode.cjs.js"
         },
         "./package.json": "./package.json"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "types": "index.d.ts",
     "exports": {
         ".": {
-            "types": "./index.d.ts",
+            "types": {
+                "require": "./index.d.ts",
+                "import": "./index.d.mts",
+                "default": "./index.d.mts"
+            },
             "require": "./build/jwt-decode.cjs.js",
             "import": "./build/jwt-decode.mjs",
             "default": "./build/jwt-decode.mjs"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "3.1.2",
     "description": "Decode JWT tokens, mostly useful for browser applications.",
     "main": "build/jwt-decode.cjs.js",
-    "module": "build/jwt-decode.esm.js",
+    "module": "build/jwt-decode.mjs",
     "types": "index.d.mts",
     "exports": {
         ".": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "types": "index.d.ts",
     "exports": {
         ".": {
+            "types": "./index.d.ts",
             "require": "./build/jwt-decode.cjs.js",
             "import": "./build/jwt-decode.mjs",
             "default": "./build/jwt-decode.mjs"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default [{
         output: {
             name: "jwt_decode",
             file: "build/jwt-decode.js",
-            format: "umd"
+            format: "umd",
         },
     },
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default [{
         output: {
             name: "jwt_decode",
             file: "build/jwt-decode.js",
-            format: "umd",
+            format: "umd"
         },
     },
     {
@@ -43,15 +43,6 @@ export default [{
             file: "build/jwt-decode.mjs",
             format: "esm",
         }],
-        plugins,
-    },
-    {
-        input: "lib/index.js",
-        output: [{
-            name: EXPORT_NAME,
-            file: "build/jwt-decode.esm.js",
-            format: "esm",
-        }, ],
         plugins: [!isProduction &&
             serve({
                 contentBase: ["build", "static"],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,6 +40,15 @@ export default [{
         input: "lib/index.js",
         output: [{
             name: EXPORT_NAME,
+            file: "build/jwt-decode.mjs",
+            format: "esm",
+        }],
+        plugins,
+    },
+    {
+        input: "lib/index.js",
+        output: [{
+            name: EXPORT_NAME,
             file: "build/jwt-decode.esm.js",
             format: "esm",
         }, ],

--- a/static/index.html
+++ b/static/index.html
@@ -10,7 +10,7 @@
     <pre><code class="js-decoded"></code></pre>
 
     <script type="module">
-      import jwtDecode from "/jwt-decode.esm.js";
+      import jwtDecode from "/jwt-decode.mjs";
       var token =
         "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJleHAiOjEzOTMyODY4OTMsImlhdCI6MTM5MzI2ODg5M30.4-iaDojEVl0pJQMjrbM1EzUIfAZgsbK_kgnVyVxFSVo";
       var decoded = jwtDecode(token);


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Adds support for loading this module natively as `esm` from node.js.
This also makes it possible to consume this module with the new `nodenext` and `node16` typescript module resolvers.
This is not possible in the current state of affairs, because the `.d.ts` file is written for `esm` modules while typescript will attempt to load the commonjs version of the package.


### References

https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/
https://nodejs.org/api/packages.html#exports