### PR TITLE
More helpful error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,23 @@ console.log(decodedHeader);
  */
 ```
 
-**Note:** A falsy or malformed token will throw an `InvalidTokenError` error.
+**Note:** A falsy or malformed token will throw an `InvalidTokenError` error; see below for more information on specific errors.
+
+## Errors
+
+This library works with valid JSON web tokens. The basic format of these token is
+```
+[part1].[part2].[part3]
+```
+All parts are supposed to be valid base64 (url) encoded json.
+Depending on the `{ header: <option> }` option it will decode part 1 (only if header: true is specified) or part 2 (default)
+
+Not adhering to the format will result in a `InvalidTokenError` with one of the following messages:
+
+- `Invalid token specified: must be a string` => the token passed was not a string, this library only works on strings. 
+- `Invalid token specified: missing part #` => this probably means you are missing a dot (`.`) in the token 
+- `Invalid token specified: invalid base64 for part #` => the part could not be base64 decoded (the message should contain the error the base64 decoder gave)
+- `Invalid token specified: invalid json for part #` => the part was correctly base64 decoded, however the decoded value was not valid json (the message should contain the error the json parser gave)
 
 ## Use with typescript
 

--- a/build/jwt-decode.js
+++ b/build/jwt-decode.js
@@ -1,7 +1,7 @@
 (function (factory) {
     typeof define === 'function' && define.amd ? define(factory) :
     factory();
-}((function () { 'use strict';
+})((function () { 'use strict';
 
     /**
      * The code was extracted from:
@@ -73,7 +73,7 @@
                 output += "=";
                 break;
             default:
-                throw "Illegal base64url string!";
+                throw new Error("base64 string is not of the correct length");
         }
 
         try {
@@ -92,15 +92,27 @@
 
     function jwtDecode(token, options) {
         if (typeof token !== "string") {
-            throw new InvalidTokenError("Invalid token specified");
+            throw new InvalidTokenError("Invalid token specified: must be a string");
         }
 
         options = options || {};
         var pos = options.header === true ? 0 : 1;
+
+        var part = token.split(".")[pos];
+        if (typeof part !== "string") {
+            throw new InvalidTokenError("Invalid token specified: missing part #" + (pos + 1));
+        }
+
         try {
-            return JSON.parse(base64_url_decode(token.split(".")[pos]));
+            var decoded = base64_url_decode(part);
         } catch (e) {
-            throw new InvalidTokenError("Invalid token specified: " + e.message);
+            throw new InvalidTokenError("Invalid token specified: invalid base64 for part #" + (pos + 1) + ' (' + e.message + ')');
+        }
+
+        try {
+            return JSON.parse(decoded);
+        } catch (e) {
+            throw new InvalidTokenError("Invalid token specified: invalid json for part #" + (pos + 1) + ' (' + e.message + ')');
         }
     }
 
@@ -119,5 +131,5 @@
         }
     }
 
-})));
+}));
 //# sourceMappingURL=jwt-decode.js.map

--- a/lib/base64_url_decode.js
+++ b/lib/base64_url_decode.js
@@ -24,7 +24,7 @@ export default function(str) {
             output += "=";
             break;
         default:
-            throw "Illegal base64url string!";
+            throw new Error("base64 string is not of the correct length");
     }
 
     try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,14 +11,26 @@ InvalidTokenError.prototype.name = "InvalidTokenError";
 
 export default function(token, options) {
     if (typeof token !== "string") {
-        throw new InvalidTokenError("Invalid token specified");
+        throw new InvalidTokenError("Invalid token specified: must be a string");
     }
 
     options = options || {};
     var pos = options.header === true ? 0 : 1;
+
+    var part = token.split(".")[pos]
+    if (typeof part !== "string") {
+        throw new InvalidTokenError("Invalid token specified: missing part #" + (pos + 1));
+    }
+
     try {
-        return JSON.parse(base64_url_decode(token.split(".")[pos]));
+        var decoded = base64_url_decode(part)
     } catch (e) {
-        throw new InvalidTokenError("Invalid token specified: " + e.message);
+        throw new InvalidTokenError("Invalid token specified: invalid base64 for part #" + (pos + 1) + ' (' + e.message + ')');
+    }
+
+    try {
+        return JSON.parse(decoded);
+    } catch (e) {
+        throw new InvalidTokenError("Invalid token specified: invalid json for part #" + (pos + 1) + ' (' + e.message + ')');
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -8,6 +8,9 @@
   <body>
     <h2>decoded:</h2>
     <pre><code class="js-decoded"></code></pre>
+    <pre><code class="js-error1"></code></pre>
+    <pre><code class="js-error2"></code></pre>
+    <pre><code class="js-error3"></code></pre>
 
     <script type="module">
       import jwtDecode from "/jwt-decode.esm.js";
@@ -19,6 +22,43 @@
         null,
         4
       );
+
+      var tokenError1 =
+              "FAKE_TOKEN";
+      try {
+        var decoded = jwtDecode(tokenError1);
+      } catch (e) {
+        document.querySelector(".js-error1").innerHTML = JSON.stringify(
+                e,
+                null,
+                4
+        );
+      }
+
+      var tokenError2 =
+              "FAKE.TOKEN2";
+      try {
+        var decoded = jwtDecode(tokenError2);
+      } catch (e) {
+        document.querySelector(".js-error2").innerHTML = JSON.stringify(
+                e,
+                null,
+                4
+        );
+      }
+
+      var tokenError3 =
+              "FAKE.TOKEN";
+      try {
+        var decoded = jwtDecode(tokenError3);
+      } catch (e) {
+        document.querySelector(".js-error3").innerHTML = JSON.stringify(
+                e,
+                null,
+                4
+        );
+      }
+
     </script>
   </body>
 </html>

--- a/test/tests.js
+++ b/test/tests.js
@@ -54,4 +54,37 @@ describe("jwt-decode", function() {
             expect(e.name).to.be("InvalidTokenError");
         });
     });
+
+    it("should throw InvalidTokenErrors that are helpful #1", function() {
+        var bad_token = "FAKE_TOKEN";
+        expect(function() {
+            jwt_decode(bad_token);
+        }).to.throwException(function(e) {
+            expect(e.name).to.be("InvalidTokenError");
+            expect(e.message).to.not.contain("undefined");
+            expect(e.message).to.not.contain("replace");
+        });
+    });
+
+    it("should throw InvalidTokenErrors that are helpful #2", function() {
+        var bad_token = "FAKE.TOKEN";
+        expect(function() {
+            jwt_decode(bad_token);
+        }).to.throwException(function(e) {
+            expect(e.name).to.be("InvalidTokenError");
+            expect(e.message).to.not.contain("undefined");
+            expect(e.message).to.not.contain("replace");
+        });
+    });
+
+    it("should throw InvalidTokenErrors that are helpful #3", function() {
+        var bad_token = "FAKE.TOKEN2";
+        expect(function() {
+            jwt_decode(bad_token);
+        }).to.throwException(function(e) {
+            expect(e.name).to.be("InvalidTokenError");
+            expect(e.message).to.not.contain("undefined");
+            expect(e.message).to.not.contain("replace");
+        });
+    });
 });


### PR DESCRIPTION

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The current error messages can be a bit confusing; especially the `cannot read property 'replace' of undefined` error (see #72).
This adds 2 more checks to give more helpful messages and replaces the `throw "<msg>"` in base64_url_decode with `throw new Error("<msg>")` as the former lead to undefined error messages.
Tests are added and the README is updated with the different error messages.

### References

- #72 

### Testing

All prior unit tests still succeed, the `static/index.html` file is updated with error cases showcasing the errors, and the readme is updated documenting the errrors.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
