### PR TITLE
Add tests for single and double padding

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -37,6 +37,27 @@ describe("jwt-decode", function() {
         expect(decoded.name).to.equal("José");
     });
 
+    it("should work with charCodes of length 1", function() {
+        var utf8_token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9zw6kiLCJpYXQiOjE0MjU2NDQ5NjZ9.1CfFtdGUPs6q8kT3OGQSVlhEMdbuX0HfNSqum0023a0";
+        var decoded = jwt_decode(utf8_token);
+        expect(decoded.name).to.equal("José");
+    });
+
+    it("should work with double padding", function() {
+        var utf8_token =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpvc8OpIiwiaWF0IjoxNTE2MjM5MDIyfQ.7A3F5SUH2gbBSYVon5mas_Y-KCrWojorKQg7UKGVEIA";
+        var decoded = jwt_decode(utf8_token);
+        expect(decoded.name).to.equal("José");
+    });
+
+    it("should work with single padding", function() {
+        var utf8_token =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpvc8OpZSIsImlhdCI6MTUxNjIzOTAyMn0.tbjJzDAylkKSV0_YGR5xBJBlFK01C82nZPLIcA3JX1g";
+        var decoded = jwt_decode(utf8_token);
+        expect(decoded.name).to.equal("Josée");
+    });
+
     it("should throw InvalidTokenError on nonstring", function() {
         var bad_token = null;
         expect(function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -37,13 +37,6 @@ describe("jwt-decode", function() {
         expect(decoded.name).to.equal("José");
     });
 
-    it("should work with charCodes of length 1", function() {
-        var utf8_token =
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9zw6kiLCJpYXQiOjE0MjU2NDQ5NjZ9.1CfFtdGUPs6q8kT3OGQSVlhEMdbuX0HfNSqum0023a0";
-        var decoded = jwt_decode(utf8_token);
-        expect(decoded.name).to.equal("José");
-    });
-
     it("should work with double padding", function() {
         var utf8_token =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpvc8OpIiwiaWF0IjoxNTE2MjM5MDIyfQ.7A3F5SUH2gbBSYVon5mas_Y-KCrWojorKQg7UKGVEIA";


### PR DESCRIPTION
### Description

This PR adds missing tests for the single and double padding.

### References

Closes #131 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
