### PR TITLE
Improve performance

### DIFF
--- a/lib/base64_url_decode.js
+++ b/lib/base64_url_decode.js
@@ -1,16 +1,14 @@
 import atob from "./atob";
 
 function b64DecodeUnicode(str) {
-    return decodeURIComponent(
-        atob(str).replace(/(.)/g, function(m, p) {
-            var code = p.charCodeAt(0).toString(16).toUpperCase();
-            if (code.length < 2) {
-                code = "0" + code;
-            }
-            return "%" + code;
-        })
-    );
-}
+    var accumulator = '';
+    var bytes = atob(str);
+    for (var i = 0; i < bytes.length; i++) {
+        var hex = bytes.charCodeAt(i).toString(16);
+        accumulator += (hex.length < 2 ? '%0' : '%') + hex;
+    }
+   return decodeURIComponent(accumulator.toUpperCase());
+ }
 
 export default function(str) {
     var output = str.replace(/-/g, "+").replace(/_/g, "/");


### PR DESCRIPTION

### Description

PR speeds up b64DecodeUnicode threefold (on my machine with Chrome, ymmv) while still keeping the code readable. Measurements: https://jsben.ch/r2u3u

This is not a breaking change, and no new browser/engine API is being used that could cause breakage with older engines. Also, there is actually a small file size decrease both for the mjs and cjs build artifacts.

### Testing

Existing tests cover this.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
