### PR TITLE
Add browser dropdown to bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -56,3 +56,19 @@ body:
       label: jwt-decode version
     validations:
       required: true
+
+  - type: dropdown
+    id: environment-browser
+    attributes:
+      label: Which browsers have you tested in?
+      multiple: true
+      options:
+        - Chrome
+        - Edge
+        - Safari
+        - Firefox
+        - Opera
+        - IE
+        - Other
+    validations:
+      required: true


### PR DESCRIPTION
### Description

This PR adds a new field to the **bug report** issue form, a dropdown to select which browsers have been used to test with.

<img width="323" alt="Screenshot 2023-04-26 at 11 11 59 PM" src="https://user-images.githubusercontent.com/5055789/234742782-1bfbb5cc-138d-4137-8b47-ab97008e8deb.png">

This field was added to the respective form of other browser libraries: https://github.com/auth0/lock/pull/2324, https://github.com/auth0/auth0.js/pull/1302, https://github.com/auth0/angular-lock/pull/71.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
