### PR TITLE
Update atob polyfill export mechanism

### DIFF
--- a/lib/atob.js
+++ b/lib/atob.js
@@ -39,7 +39,15 @@ function polyfill(input) {
     return output;
 }
 
-export default (typeof window !== "undefined" &&
-    window.atob &&
-    window.atob.bind(window)) ||
-polyfill;
+// globalThis supported and atob implemented
+if (typeof globalThis !== "undefined" && globalThis.atob) {
+    export globalThis.atob.bind(globalThis);
+} 
+// no globalThis support, however window present and atob implemented
+else if (typeof window !== "undefined" && window.atob) {
+    export window.atob.bind(window);
+} 
+// missing atob support, polyfill it.
+else {
+    export polyfill;
+}


### PR DESCRIPTION
Change export mechanism.
1. Check first for presence of globalThis + atob.
2. Secondly check for window + atob
3. Finally polyfill if none of the above implementations are present

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
This ensures that we don't polyfill unecessary on the server side, since the expression `type of window !== "undefined"`, will always evaluate to false on the server side.

However by adding a check on [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) first we ensure to check on the globalThis object instead which is present both on the server and client.
![Screenshot 2023-06-20 at 18 13 06](https://github.com/auth0/jwt-decode/assets/155505/67ea9efc-e637-4291-a79d-07fc747c4094)



### References

There are no proposals for this, but it's a nice to have rather than using a polyfill on the server which is most likely not used.

This is also how it's done in [core-js](https://github.com/zloirock/core-js/blob/55608b6965cd445eb5588188b6be9f202a2d29bf/packages/core-js/internals/global.js#L5-L9):
```js
// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
module.exports =
  // eslint-disable-next-line es/no-global-this -- safe
  check(typeof globalThis == 'object' && globalThis) ||
  check(typeof window == 'object' && window) ||
```

**See support for GlobalThis**
* https://caniuse.com/?search=atob
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

**Articles supporting use of globalThis**
* [What is globalThis, and why should you start using it?](https://blog.logrocket.com/what-is-globalthis-why-use-it/)
* [WHY YOU SHOULD BE USING GLOBALTHIS INSTEAD OF WINDOW IN YOUR JAVASCRIPT CODE](https://ilikekillnerds.com/2023/02/why-you-should-be-using-globalthis-instead-of-window-in-your-javascript-code/)
### Testing

The current change should not affect testing, if there is a need for test i can add it. Which could check that the polyfill method is never called on the server. However not sure how much a need there is for this.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
