### PR TITLE
Enforce JWT structure by adding validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -56,3 +56,19 @@ body:
       label: jwt-decode version
     validations:
       required: true
+
+  - type: dropdown
+    id: environment-browser
+    attributes:
+      label: Which browsers have you tested in?
+      multiple: true
+      options:
+        - Chrome
+        - Edge
+        - Safari
+        - Firefox
+        - Opera
+        - IE
+        - Other
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ console.log(decodedHeader);
  *   alg: "HS256" 
  * }
  */
+
+// optionally, a data validation can be requested
+var decodedAndValidated = jwt_decode(token, { validate: true });
+var decodedHeaderAndValidated = jwt_decode(token, { header: true, validate: true });
+
 ```
 
 **Note:** A falsy or malformed token will throw an `InvalidTokenError` error; see below for more information on specific errors.
@@ -60,7 +65,7 @@ This library works with valid JSON web tokens. The basic format of these token i
 [part1].[part2].[part3]
 ```
 All parts are supposed to be valid base64 (url) encoded json.
-Depending on the `{ header: <option> }` option it will decode part 1 (only if header: true is specified) or part 2 (default)
+Depending on the `{ header: <option> }` option it will decode part 1 (only if header: true is specified) or part 2 (default).
 
 Not adhering to the format will result in a `InvalidTokenError` with one of the following messages:
 
@@ -68,6 +73,7 @@ Not adhering to the format will result in a `InvalidTokenError` with one of the 
 - `Invalid token specified: missing part #` => this probably means you are missing a dot (`.`) in the token 
 - `Invalid token specified: invalid base64 for part #` => the part could not be base64 decoded (the message should contain the error the base64 decoder gave)
 - `Invalid token specified: invalid json for part #` => the part was correctly base64 decoded, however the decoded value was not valid json (the message should contain the error the json parser gave)
+- `Invalid token specified: failed to validate` => when `{ validate: true }`, the decoded part failed to validate according to the expected format.
 
 #### Use with typescript
 

--- a/build/jwt-decode.js
+++ b/build/jwt-decode.js
@@ -110,10 +110,76 @@
         }
 
         try {
-            return JSON.parse(decoded);
+            var parsed = JSON.parse(decoded);
         } catch (e) {
             throw new InvalidTokenError("Invalid token specified: invalid json for part #" + (pos + 1) + ' (' + e.message + ')');
         }
+
+        
+        if(options.validate && options.header){
+          var validationError = validateHeader(parsed);
+        } else if(options.validate && !options.header){
+          var validationError = validatePayload(parsed);
+        } else {
+            var validationError = undefined;
+        }
+
+        if(validationError){
+             throw new InvalidTokenError("Invalid token specified: failed to validate, error:" + validationError);
+        }
+
+        return parsed;
+    }
+
+    function validateHeader(obj){
+        if(typeof obj !== "object"){
+            return "header expected to be an object"
+        }
+
+        // select all fields that are not valid
+        var invalidFields = ["typ", "alg", "kid"].filter(function(name){
+            return !isNullOrString(obj, name);
+        });
+        if(invalidFields.length){
+            return "fields " + invalidFields.join(", ") + " expected to be string or undefined"
+        }
+    }
+
+    function validatePayload(obj){
+        if(typeof obj !== "object"){
+            throw new InvalidTokenError("payload expected to be an object");
+        }
+
+        // select all fields that are not valid
+        var invalidStringFields = ["iss", "sub", "jti"].filter(function(name){
+            return !isNullOrString(obj, name);
+        });
+        var invalidNumberFields = ["exp", "nbf", "iat"].filter(function(name){
+            return !isNullOrNumber(obj, name);
+        });
+        var invalidArrayOfStringFields = ["aud"].filter(function(name){
+            return !isNullOrString(obj, name) && !isNullOrArrayOfString(obj, name);
+        });
+
+        var invalidFields = [...invalidStringFields, ...invalidNumberFields,...invalidArrayOfStringFields ];
+        if(invalidFields.length){
+            throw new InvalidTokenError("Invalid token specified: invalid payload fields " + invalidFields.join(", ") + " expected to be string or undefined");
+        }
+    }
+
+    function isNullOrString(obj, name){
+        var value = obj[name];
+        return typeof value === "undefined" ||  typeof value === "string"
+    }
+
+    function isNullOrArrayOfString(obj, name){
+        var value = obj[name];
+        return Array.isArray(value) && value.every(function(item){ return typeof item === "string" })
+    }
+
+    function isNullOrNumber(obj, name){
+        var value = obj[name];
+        return typeof value === "undefined" ||  typeof value === "number"
     }
 
     /*

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ export class InvalidTokenError extends Error {}
 
 export interface JwtDecodeOptions {
   header?: boolean;
+  validate?: boolean;
 }
 
 export interface JwtHeader {
@@ -20,6 +21,14 @@ export interface JwtPayload {
   jti?: string;
 }
 
+export default function jwtDecode(
+  token: string,
+  options?: JwtDecodeOptions & { header: true; validate: true }
+): JwtHeader;
+export default function jwtDecode(
+  token: string,
+  options?: JwtDecodeOptions & { header?: false; validate: true }
+): JwtPayload;
 export default function jwtDecode<T = unknown>(
   token: string,
   options?: JwtDecodeOptions

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,8 +29,75 @@ export default function(token, options) {
     }
 
     try {
-        return JSON.parse(decoded);
+        var parsed = JSON.parse(decoded);
     } catch (e) {
         throw new InvalidTokenError("Invalid token specified: invalid json for part #" + (pos + 1) + ' (' + e.message + ')');
     }
+
+    
+    if(options.validate && options.header){
+        var validationError = validateHeader(parsed);
+    } else if(options.validate && !options.header){
+        var validationError = validatePayload(parsed);
+    } else {
+        var validationError = undefined;
+    }
+
+    if(validationError){
+        throw new InvalidTokenError("Invalid token specified: failed to validate, error:" + validationError);
+    }
+
+    return parsed;
 }
+
+function validateHeader(obj){
+    if(typeof obj !== "object"){
+        return "header expected to be an object"
+    }
+
+    // select all fields that are not valid
+    var invalidFields = ["typ", "alg", "kid"].filter(function(name){
+        return !isNullOrString(obj, name);
+    });
+    if(invalidFields.length){
+        return "fields " + invalidFields.join(", ") + " expected to be string or undefined"
+    }
+}
+
+function validatePayload(obj){
+    if(typeof obj !== "object"){
+        throw new InvalidTokenError("payload expected to be an object");
+    }
+
+    // select all fields that are not valid
+    var invalidStringFields = ["iss", "sub", "jti"].filter(function(name){
+        return !isNullOrString(obj, name);
+    });
+    var invalidNumberFields = ["exp", "nbf", "iat"].filter(function(name){
+        return !isNullOrNumber(obj, name);
+    });
+    var invalidArrayOfStringFields = ["aud"].filter(function(name){
+        return !isNullOrString(obj, name) && !isNullOrArrayOfString(obj, name);
+    });
+
+    var invalidFields = [...invalidStringFields, ...invalidNumberFields,...invalidArrayOfStringFields ]
+    if(invalidFields.length){
+        throw new InvalidTokenError("fields " + invalidFields.join(", ") + " expected to be string or undefined");
+    }
+}
+
+function isNullOrString(obj, name){
+    var value = obj[name];
+    return typeof value === "undefined" ||  typeof value === "string"
+}
+
+function isNullOrArrayOfString(obj, name){
+    var value = obj[name];
+    return Array.isArray(value) && value.every(function(item){ return typeof item === "string" })
+}
+
+function isNullOrNumber(obj, name){
+    var value = obj[name];
+    return typeof value === "undefined" ||  typeof value === "number"
+}
+

--- a/test/tests.js
+++ b/test/tests.js
@@ -138,4 +138,45 @@ describe("jwt-decode", function() {
             expect(e.message).to.contain("Invalid token specified: invalid json for part #2");
         });
     });
+
+    describe("validation", function() {
+        it("should return header information on bad token when no validation is required", function() {
+            // invalid alg=12345
+            var token = "eyJhbGciOiAxMjM0NSwidHlwIjogIkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjEzOTMyODY4OTMsImlhdCI6MTM5MzI2ODg5M30.4-iaDojEVl0pJQMjrbM1EzUIfAZgsbK_kgnVyVxFSVo";
+            var decoded = jwt_decode(token, { header: true });
+            expect(decoded.alg).to.equal(12345);
+        });
+
+        it("should throw InvalidTokenError on bad header when validation is required", function() {
+            // invalid alg=12345
+            var token = "eyJhbGciOiAxMjM0NSwidHlwIjogIkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjEzOTMyODY4OTMsImlhdCI6MTM5MzI2ODg5M30.4-iaDojEVl0pJQMjrbM1EzUIfAZgsbK_kgnVyVxFSVo";
+    
+            expect(function() {
+                jwt_decode(token, { header: true, validate: true });
+            }).to.throwException(function(e) {
+                expect(e.name).to.be("InvalidTokenError");
+            });
+        });
+
+        it("should return payload information on bad token when no validation is required", function() {
+            // invalid iat
+            var token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiAiMTIzNDU2Nzg5MCIsIm5hbWUiOiAiSm9obiBEb2UiLCJpYXQiOiJzaG91bGQtYmUtbnVtYmVyIn0.4-iaDojEVl0pJQMjrbM1EzUIfAZgsbK_kgnVyVxFSVo";
+    
+            var decoded = jwt_decode(token);
+            expect(decoded.iat).to.equal("should-be-number");
+        });
+
+        it("should throw InvalidTokenError on bad payload when validation is required", function() {
+            // invalid iat
+            var token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiAiMTIzNDU2Nzg5MCIsIm5hbWUiOiAiSm9obiBEb2UiLCJpYXQiOiJzaG91bGQtYmUtbnVtYmVyIn0.4-iaDojEVl0pJQMjrbM1EzUIfAZgsbK_kgnVyVxFSVo";
+    
+            expect(function() {
+                jwt_decode(token, { validate: true });
+            }).to.throwException(function(e) {
+                expect(e.name).to.be("InvalidTokenError");
+            });
+        });
+    });
+
 });
+


### PR DESCRIPTION
### Description

Even though there are `JwtHeader` and `JwtPayload` in type definitions,  users cannot trust the function `jwtDecode` to return results in the expected format. This PR aims to solve the issue by:
* explicitly overloading the `jwtDecode` function depending on which JWT part we are decoding
  * _the old type definition has been kept for compatibility_
* applying an optional validation to the parsed token when passing `{ validate: true }` as option.


### Testing

A whole `validation` section has been added to unit tests.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
