### PR TITLE
feat: add support for node atob

### DIFF
--- a/build/jwt-decode.js
+++ b/build/jwt-decode.js
@@ -44,9 +44,13 @@
     return output;
   }
 
-  var atob = (typeof window !== "undefined" &&
-    window.atob &&
-    window.atob.bind(window)) ||
+  const global =
+    (typeof globalThis !== "undefined" && globalThis) ||
+    (typeof window !== "undefined" && window);
+
+  var atob = (typeof global !== "undefined" &&
+    global.atob &&
+    global.atob.bind(global)) ||
     polyfill;
 
   function b64DecodeUnicode(str) {

--- a/lib/atob.js
+++ b/lib/atob.js
@@ -39,7 +39,11 @@ function polyfill(input) {
   return output;
 }
 
-export default (typeof window !== "undefined" &&
-  window.atob &&
-  window.atob.bind(window)) ||
+const global =
+  (typeof globalThis !== "undefined" && globalThis) ||
+  (typeof window !== "undefined" && window);
+
+export default (typeof global !== "undefined" &&
+  global.atob &&
+  global.atob.bind(global)) ||
   polyfill;


### PR DESCRIPTION
### Description

When running on a version of node that supports atob (16+), we use the platform instead of our polyfil.

This introduces the same coverage drop when running the tests against node, due to the fact that the polyfill no longer is used on node.

![image](https://github.com/auth0/jwt-decode/assets/2146903/6d266e75-d0f8-4804-8186-805a9cba0af5)

**Note: this is a breaking change.**

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
