### PR TITLE
feat: run tests against multiple node versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
 version: 2.1
 jobs:
   build:
+    parameters:
+      node-version:
+        type: string
+        default: "18"
     docker:
-      - image: circleci/node:14-browsers
+      - image: cimg/node:<< parameters.node-version >>
     environment:
       LANG: en_US.UTF-8
     steps:
@@ -23,3 +27,6 @@ workflows:
   build-and-test:
     jobs:
       - build
+          matrix:
+            parameters:
+              node-version: ["14.20", "16.20", "18.16"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - build
+      - build:
           matrix:
             parameters:
               node-version: ["14.20", "16.20", "18.16"]


### PR DESCRIPTION
### Description

Even though this SDK is advertised mainly for browsers, it works fine in node. Adding Circle CI matrix configuration to run tests on multiple node versions.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
