### PR TITLE
Replace `.npmignore` with `files` field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.github
-node_modules
-lib
-test
-static
-.gitignore
-.npmignore
-rollup.config.js
-.vscode

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
         "uglify-js": "^3.15.2"
     },
     "files": [
-        "build/",
-        "index.d.ts"
+        "build"
     ],
     "engines": {
         "node": ">=16"


### PR DESCRIPTION
Removes the `.npmignore` file and replaces it with the [`files` field](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files) in the package file. Since the `files` field is used as an allowlist during [`npm pack`](https://docs.npmjs.com/cli/v9/commands/npm-pack), there is no need to keep the `.npmignore` around.