### PR TITLE
Add a `prepublishOnly` script for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "postbuild": "echo '{\"type\": \"commonjs\"}'> build/cjs/package.json",
         "test": "npm run test:node && npm run test:browser",
         "test:node": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --coverage",
-        "test:browser": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --coverage --testEnvironment=jsdom"
+        "test:browser": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --coverage --testEnvironment=jsdom",
+        "prepublishOnly": "npm run build && npm run test"
     },
     "author": "Jose F. Romaniello <jfromaniello@gmail.com>",
     "contributors": [


### PR DESCRIPTION
Adds a `prepublishOnly` script, which will run before the package is published through `npm publish`. This script will run the build and tests, so that a broken package is not shipped by accident.