### PR TITLE
Remove unused Rollup dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
             "version": "3.1.2",
             "license": "MIT",
             "devDependencies": {
-                "@rollup/plugin-commonjs": "^21.0.2",
-                "@rollup/plugin-node-resolve": "^13.1.3",
                 "jest": "^29.6.0",
                 "jest-environment-jsdom": "^29.6.0",
                 "jest-junit": "^16.0.0",
@@ -1354,56 +1352,6 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/@rollup/plugin-commonjs": {
-            "version": "21.0.2",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.2.tgz",
-            "integrity": "sha512-d/OmjaLVO4j/aQX69bwpWPpbvI3TJkQuxoAk7BH8ew1PyoMBLTOuvJTjzG8oEoW7drIIqB0KCJtfFLu/2GClWg==",
-            "dev": true,
-            "dependencies": {
-                "@rollup/pluginutils": "^3.1.0",
-                "commondir": "^1.0.1",
-                "estree-walker": "^2.0.1",
-                "glob": "^7.1.6",
-                "is-reference": "^1.2.1",
-                "magic-string": "^0.25.7",
-                "resolve": "^1.17.0"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^2.38.3"
-            }
-        },
-        "node_modules/@rollup/plugin-node-resolve": {
-            "version": "13.1.3",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-            "integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
-            "dev": true,
-            "dependencies": {
-                "@rollup/pluginutils": "^3.1.0",
-                "@types/resolve": "1.17.1",
-                "builtin-modules": "^3.1.0",
-                "deepmerge": "^4.2.2",
-                "is-module": "^1.0.0",
-                "resolve": "^1.19.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^2.42.0"
-            }
-        },
-        "node_modules/@rollup/plugin-node-resolve/node_modules/@types/resolve": {
-            "version": "1.17.1",
-            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
-            "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@rollup/pluginutils": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -1506,12 +1454,6 @@
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
-        },
-        "node_modules/@types/estree": {
-            "version": "0.0.45",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-            "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
-            "dev": true
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.6",
@@ -1974,15 +1916,6 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
-        },
-        "node_modules/builtin-modules": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-            "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -2875,12 +2808,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-            "dev": true
-        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2895,15 +2822,6 @@
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true
-        },
-        "node_modules/is-reference": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "*"
-            }
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
@@ -4909,15 +4827,6 @@
                 "yallist": "^3.0.2"
             }
         },
-        "node_modules/magic-string": {
-            "version": "0.25.7",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-            "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-            "dev": true,
-            "dependencies": {
-                "sourcemap-codec": "^1.4.4"
-            }
-        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5725,12 +5634,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "node_modules/sourcemap-codec": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-            "dev": true
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
@@ -7375,46 +7278,6 @@
             "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
             "dev": true
         },
-        "@rollup/plugin-commonjs": {
-            "version": "21.0.2",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.2.tgz",
-            "integrity": "sha512-d/OmjaLVO4j/aQX69bwpWPpbvI3TJkQuxoAk7BH8ew1PyoMBLTOuvJTjzG8oEoW7drIIqB0KCJtfFLu/2GClWg==",
-            "dev": true,
-            "requires": {
-                "@rollup/pluginutils": "^3.1.0",
-                "commondir": "^1.0.1",
-                "estree-walker": "^2.0.1",
-                "glob": "^7.1.6",
-                "is-reference": "^1.2.1",
-                "magic-string": "^0.25.7",
-                "resolve": "^1.17.0"
-            }
-        },
-        "@rollup/plugin-node-resolve": {
-            "version": "13.1.3",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-            "integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
-            "dev": true,
-            "requires": {
-                "@rollup/pluginutils": "^3.1.0",
-                "@types/resolve": "1.17.1",
-                "builtin-modules": "^3.1.0",
-                "deepmerge": "^4.2.2",
-                "is-module": "^1.0.0",
-                "resolve": "^1.19.0"
-            },
-            "dependencies": {
-                "@types/resolve": {
-                    "version": "1.17.1",
-                    "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
-                    "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-                    "dev": true,
-                    "requires": {
-                        "@types/node": "*"
-                    }
-                }
-            }
-        },
         "@rollup/pluginutils": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -7510,12 +7373,6 @@
             "requires": {
                 "@babel/types": "^7.20.7"
             }
-        },
-        "@types/estree": {
-            "version": "0.0.45",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-            "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
-            "dev": true
         },
         "@types/graceful-fs": {
             "version": "4.1.6",
@@ -7875,12 +7732,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
-        },
-        "builtin-modules": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-            "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
             "dev": true
         },
         "callsites": {
@@ -8534,12 +8385,6 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-            "dev": true
-        },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8551,15 +8396,6 @@
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true
-        },
-        "is-reference": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-            "dev": true,
-            "requires": {
-                "@types/estree": "*"
-            }
         },
         "is-stream": {
             "version": "2.0.1",
@@ -10050,15 +9886,6 @@
                 "yallist": "^3.0.2"
             }
         },
-        "magic-string": {
-            "version": "0.25.7",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-            "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-            "dev": true,
-            "requires": {
-                "sourcemap-codec": "^1.4.4"
-            }
-        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -10663,12 +10490,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "sourcemap-codec": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-            "dev": true
         },
         "sprintf-js": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     ],
     "license": "MIT",
     "devDependencies": {
-        "@rollup/plugin-commonjs": "^21.0.2",
-        "@rollup/plugin-node-resolve": "^13.1.3",
         "jest": "^29.6.0",
         "jest-environment-jsdom": "^29.6.0",
         "jest-junit": "^16.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,3 @@
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
 import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import serve from "rollup-plugin-serve";
@@ -9,12 +7,6 @@ import typescript from "rollup-plugin-typescript2";
 const EXPORT_NAME = "jwt-decode";
 const isProduction = process.env.NODE_ENV === "production";
 const plugins = [
-    resolve({
-        browser: true,
-    }),
-    commonjs({
-        requireReturnsDefault: "preferred",
-    }),
     typescript({
         clean: true,
         useTsconfigDeclarationDir: true,


### PR DESCRIPTION
Removes the [`@rollup/plugin-commonjs`](https://github.com/rollup/plugins/tree/master/packages/commonjs) and [`@rollup/plugin-node-resolve`](https://github.com/rollup/plugins/tree/master/packages/node-resolve/) plugins from the dependencies and Rollup configuration. Since this package has no dependencies, and certainly none that are CommonJS-based, these can be safely removed.