### PR TITLE
Remove unused `uglify-js` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
                 "rollup-plugin-serve": "^2.0.2",
                 "rollup-plugin-typescript2": "^0.35.0",
                 "ts-jest": "^29.1.1",
-                "typescript": "^5.1.6",
-                "uglify-js": "^3.17.4"
+                "typescript": "^5.1.6"
             },
             "engines": {
                 "node": ">=16"
@@ -6218,18 +6217,6 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/uglify-js": {
-            "version": "3.17.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-            "dev": true,
-            "bin": {
-                "uglifyjs": "bin/uglifyjs"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -11186,12 +11173,6 @@
             "version": "5.1.6",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
             "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-            "dev": true
-        },
-        "uglify-js": {
-            "version": "3.17.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
             "dev": true
         },
         "universalify": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
         "rollup-plugin-serve": "^2.0.2",
         "rollup-plugin-typescript2": "^0.35.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.1.6",
-        "uglify-js": "^3.17.4"
+        "typescript": "^5.1.6"
     },
     "files": [
         "build"


### PR DESCRIPTION
Removes the `uglify-js` dependency, which is not actively used anywhere. Likely this was used at some point in the past before being replaced with `@rollup/plugin-terser`.