### PR TITLE
Replace `atob` module with default global

### DIFF
--- a/lib/atob.ts
+++ b/lib/atob.ts
@@ -1,3 +1,0 @@
-const global = (typeof globalThis !== "undefined" && globalThis) || window;
-
-export default global.atob.bind(global);

--- a/lib/base64_url_decode.ts
+++ b/lib/base64_url_decode.ts
@@ -1,5 +1,3 @@
-import atob from "./atob";
-
 function b64DecodeUnicode(str: string) {
     return decodeURIComponent(
         atob(str).replace(/(.)/g, function(m, p) {


### PR DESCRIPTION
Replaces the module that proxies `atob` through `globalThis` or `window`. Since `globalThis` is the default global, and in browsers it will reference `window`, there is no need to reference globals explicitly. This also makes the final bundle a tad smaller.