### PR TITLE
Use official TypeScript plugin for Rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "rollup": "^3.26.3",
                 "rollup-plugin-livereload": "^2.0.5",
                 "rollup-plugin-serve": "^2.0.2",
-                "rollup-plugin-typescript2": "^0.35.0",
                 "ts-jest": "^29.1.1",
                 "typescript": "^5.1.6"
             },
@@ -2232,12 +2231,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/commondir": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-            "dev": true
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2588,23 +2581,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/find-cache-dir": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-            "dev": true,
-            "dependencies": {
-                "commondir": "^1.0.1",
-                "make-dir": "^3.0.2",
-                "pkg-dir": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-            }
-        },
         "node_modules/foreground-child": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -2645,29 +2621,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/fs-extra/node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/fs.realpath": {
@@ -4930,27 +4883,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jsonfile/node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5012,21 +4944,6 @@
             "dev": true,
             "dependencies": {
                 "yallist": "^3.0.2"
-            }
-        },
-        "node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dev": true,
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/make-error": {
@@ -5692,69 +5609,6 @@
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/rollup-plugin-typescript2": {
-            "version": "0.35.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.35.0.tgz",
-            "integrity": "sha512-szcIO9hPUx3PhQl91u4pfNAH2EKbtrXaES+m163xQVE5O1CC0ea6YZV/5woiDDW3CR9jF2CszPrKN+AFiND0bg==",
-            "dev": true,
-            "dependencies": {
-                "@rollup/pluginutils": "^4.1.2",
-                "find-cache-dir": "^3.3.2",
-                "fs-extra": "^10.0.0",
-                "semver": "^7.3.7",
-                "tslib": "^2.4.0"
-            },
-            "peerDependencies": {
-                "rollup": ">=1.26.3",
-                "typescript": ">=2.4.0"
-            }
-        },
-        "node_modules/rollup-plugin-typescript2/node_modules/@rollup/pluginutils": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-            "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-            "dev": true,
-            "dependencies": {
-                "estree-walker": "^2.0.1",
-                "picomatch": "^2.2.2"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/rollup-plugin-typescript2/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/rollup-plugin-typescript2/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/rollup-plugin-typescript2/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
         "node_modules/safe-buffer": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -6181,7 +6035,9 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/type-detect": {
             "version": "4.0.8",
@@ -8239,12 +8095,6 @@
                 "delayed-stream": "~1.0.0"
             }
         },
-        "commondir": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-            "dev": true
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8512,17 +8362,6 @@
                 "to-regex-range": "^5.0.1"
             }
         },
-        "find-cache-dir": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-            "dev": true,
-            "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^3.0.2",
-                "pkg-dir": "^4.1.0"
-            }
-        },
         "foreground-child": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -8550,25 +8389,6 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
-            }
-        },
-        "fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "dependencies": {
-                "universalify": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-                    "dev": true
-                }
             }
         },
         "fs.realpath": {
@@ -10230,24 +10050,6 @@
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true
         },
-        "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-            },
-            "dependencies": {
-                "universalify": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-                    "dev": true
-                }
-            }
-        },
         "kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -10297,15 +10099,6 @@
             "dev": true,
             "requires": {
                 "yallist": "^3.0.2"
-            }
-        },
-        "make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dev": true,
-            "requires": {
-                "semver": "^6.0.0"
             }
         },
         "make-error": {
@@ -10793,55 +10586,6 @@
                 }
             }
         },
-        "rollup-plugin-typescript2": {
-            "version": "0.35.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.35.0.tgz",
-            "integrity": "sha512-szcIO9hPUx3PhQl91u4pfNAH2EKbtrXaES+m163xQVE5O1CC0ea6YZV/5woiDDW3CR9jF2CszPrKN+AFiND0bg==",
-            "dev": true,
-            "requires": {
-                "@rollup/pluginutils": "^4.1.2",
-                "find-cache-dir": "^3.3.2",
-                "fs-extra": "^10.0.0",
-                "semver": "^7.3.7",
-                "tslib": "^2.4.0"
-            },
-            "dependencies": {
-                "@rollup/pluginutils": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-                    "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-                    "dev": true,
-                    "requires": {
-                        "estree-walker": "^2.0.1",
-                        "picomatch": "^2.2.2"
-                    }
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "semver": {
-                    "version": "7.5.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-                    "dev": true
-                }
-            }
-        },
         "safe-buffer": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -11155,7 +10899,9 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
             "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "type-detect": {
             "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "rollup": "^3.26.3",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^2.0.2",
-        "rollup-plugin-typescript2": "^0.35.0",
         "ts-jest": "^29.1.1",
         "typescript": "^5.1.6"
     },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,23 +1,18 @@
 import terser from "@rollup/plugin-terser";
+import typescript from "@rollup/plugin-typescript";
 import { defineConfig } from "rollup";
 import livereload from "rollup-plugin-livereload";
 import serve from "rollup-plugin-serve";
-import typescript from "rollup-plugin-typescript2";
 
 const EXPORT_NAME = "jwt-decode";
 const isProduction = process.env.NODE_ENV === "production";
+const tsPlugin = typescript({
+    rootDir: "lib",
+    sourceMap: true,
+});
+
 const plugins = [
-    typescript({
-        clean: true,
-        useTsconfigDeclarationDir: true,
-        tsconfigOverride: {
-            noEmit: false,
-            sourceMap: true,
-            compilerOptions: {
-                lib: ['dom', 'es6']
-            }
-        }
-    }),
+    tsPlugin,
     isProduction && terser(),
 ];
 
@@ -30,17 +25,7 @@ export default defineConfig([{
             sourcemap: true,
         },
         plugins: [
-            typescript({
-                clean: true,
-                useTsconfigDeclarationDir: true,
-                tsconfigOverride: {
-                    noEmit: false,
-                    sourceMap: true,
-                    compilerOptions: {
-                        lib: ['dom', 'es6']
-                    }
-                }
-            }),
+            tsPlugin,
         ]
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
       "downlevelIteration": true,
       "noImplicitThis": true,
       "strict": true,
+      "noEmitOnError": true
     },
     "exclude": ["./test", "./build/typings"]
   }


### PR DESCRIPTION
Removes the `rollup-plugin-typescript2` plugin, and replaces it with the official [`@rollup/plugin-typescript` plugin](https://github.com/rollup/plugins/tree/master/packages/typescript/#readme). Also fixes a bug where the types for the Rollup config were emitted (see https://github.com/auth0/jwt-decode/pull/161#issuecomment-1653759208).