### PR TITLE
Release v4.0.0-beta.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,6 @@ workflows:
             branches:
               only:
                 - master
+                - beta
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ workflows:
             parameters:
               node-version: ["16.20", "18.16", "20.4"]
       - ship/node-publish:
+          publish-command: npm publish --tag beta
           context:
             - publish-npm
             - publish-gh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change log
 
+## Version [4.0.0-beta.0](https://github.com/auth0/jwt-decode/releases/tag/v4.0.0-beta.0)
+
+[Full Changelog](https://github.com/auth0/jwt-decode/compare/v3.1.2..v4.0.0-beta.0)
+
+A new version of the library, including a couple of improvements:
+
+- No longer include a polyfill for [atob](https://developer.mozilla.org/en-US/docs/Web/API/atob), as this is [supported in all major browsers](https://caniuse.com/?search=atob) (and [node environments > 14](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility)).
+- Compile to ES2017, dropping support for anything that does not support ES2017 (which should be very limited [according to caniuse](https://caniuse.com/?search=es2017))
+- Use Node's atob when running on node.
+- Drop support for Node 14, add support for Node 20.
+- Add support for package.json's `exports` field, for better CJS/ESM support
+- Reorganize build artifacts for better CJS/ESM support (cjs and esm needs to be their own directory with a cjs specific package.json file)
+- Drop manual UMD bundle creation in `index.standalone.ts`, but rely on rollup instead.
+- Infer JwtPayload and JwtHeader default types from the `header` argument by using overloads.
+
+**Additionally, this PR ensures the file size is decreased:**
+
+- **ESM and CJS decreased by 22%**
+- **UMD decreased by 37%**
+
+Even though some users might experience breaking changes, mostly because of the `exports` field, the majority should be able to update without making any changes, assuming the SDK is used in environments with support for `atob`.
+
 ## Version [3.1.2](https://github.com/auth0/jwt-decode/releases/tag/v3.1.2)
 
 [Full Changelog](https://github.com/auth0/jwt-decode/compare/v3.1.1..v3.1.2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "jwt-decode",
-    "version": "3.1.2",
+    "version": "4.0.0-beta.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "jwt-decode",
-            "version": "3.1.2",
+            "version": "4.0.0-beta.0",
             "license": "MIT",
             "devDependencies": {
                 "@rollup/plugin-terser": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jwt-decode",
-    "version": "3.1.2",
+    "version": "4.0.0-beta.0",
     "description": "Decode JWT tokens, mostly useful for browser applications.",
     "main": "build/cjs/jwt-decode.js",
     "module": "build/esm/jwt-decode.js",


### PR DESCRIPTION
A new version of the library, including a couple of improvements:

- No longer include a polyfill for [atob](https://developer.mozilla.org/en-US/docs/Web/API/atob), as this is [supported in all major browsers](https://caniuse.com/?search=atob) (and [node environments > 14](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility)).
- Compile to ES2017, dropping support for anything that does not support ES2017 (which should be very limited [according to caniuse](https://caniuse.com/?search=es2017))
- Use Node's atob when running on node.
- Drop support for Node 14, add support for Node 20.
- Add support for package.json's `exports` field, for better CJS/ESM support
- Reorganize build artifacts for better CJS/ESM support (cjs and esm needs to be their own directory with a cjs specific package.json file)
- Drop manual UMD bundle creation in `index.standalone.ts`, but rely on rollup instead.
- Infer JwtPayload and JwtHeader default types from the `header` argument by using overloads.

**Additionally, this PR ensures the file size is decreased:**

- **ESM and CJS decreased by 22%**
- **UMD decreased by 37%**

Even though some users might experience breaking changes, mostly because of the `exports` field, the majority should be able to update without making any changes, assuming the SDK is used in environments with support for `atob`.