### PR TITLE
Ensure build is run on prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "postbuild": "echo '{\"type\": \"commonjs\"}'> build/cjs/package.json",
         "test": "npm run test:node && npm run test:browser",
         "test:node": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --coverage",
-        "test:browser": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --coverage --testEnvironment=jsdom"
+        "test:browser": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --coverage --testEnvironment=jsdom",
+        "prepack": "npm run build"
     },
     "author": "Jose F. Romaniello <jfromaniello@gmail.com>",
     "contributors": [


### PR DESCRIPTION
### Description

Ensure to build before running `npm pack` or `npm publish`.


### References

See: https://github.com/auth0/jwt-decode/pull/151#issuecomment-1656697372

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
