### PR TITLE
fix: add file extension to import path to support Node16 and NodeNext module resolution

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,9 @@ const jestConfig: JestConfigWithTsJest = {
     "default",
     ["jest-junit", { outputDirectory: "test-results/jest" }],
   ],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   coverageReporters: ["lcov", "text", "text-summary"],
   setupFiles: [],
   preset: "ts-jest/presets/default-esm",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import { base64UrlDecode } from "./base64_url_decode";
+import { base64UrlDecode } from "./base64_url_decode.js";
 
 export interface JwtDecodeOptions {
   header?: boolean;

--- a/lib/index.umd.ts
+++ b/lib/index.umd.ts
@@ -1,1 +1,1 @@
-export { jwtDecode as default } from './index';
+export { jwtDecode as default } from './index.js';


### PR DESCRIPTION
### Description

When using node16 or nodenext moduleresolution, tsc would throw errors. See #169 

### References

> relative import paths need full extensions (e.g we have to write import "./foo.js" instead of import "./foo")

[typescriptlang.org/docs/handbook/esm-node.html](https://www.typescriptlang.org/docs/handbook/esm-node.html)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
