### PR TITLE
Clean up Rollup config

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -4,7 +4,6 @@ import { defineConfig } from "rollup";
 import livereload from "rollup-plugin-livereload";
 import serve from "rollup-plugin-serve";
 
-const EXPORT_NAME = "jwt-decode";
 const isProduction = process.env.NODE_ENV === "production";
 const tsPlugin = typescript({
   rootDir: "lib",
@@ -16,8 +15,10 @@ const plugins = [
   isProduction && terser(),
 ];
 
+const input = "lib/index.ts";
+
 export default defineConfig([{
-    input: "lib/index.ts",
+    input,
     output: {
       name: "jwt_decode",
       file: "build/jwt-decode.js",
@@ -29,24 +30,21 @@ export default defineConfig([{
     ]
   },
   {
-    input: "lib/index.ts",
-    output: [{
-      name: EXPORT_NAME,
+    input,
+    output: {
       file: "build/cjs/jwt-decode.js",
       format: "cjs",
-      exports: "auto",
       sourcemap: true,
-    }, ],
+    },
     plugins,
   },
   {
-    input: "lib/index.ts",
-    output: [{
-      name: EXPORT_NAME,
+    input,
+    output: {
       file: "build/esm/jwt-decode.js",
       format: "esm",
       sourcemap: true,
-    }, ],
+    },
     plugins: [!isProduction &&
       serve({
         contentBase: ["build", "static"],

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1,4 +1,4 @@
-import jwt_decode, { InvalidTokenError, JwtPayload } from "./../lib/index";
+import { jwtDecode, InvalidTokenError, JwtPayload } from "./../lib/index";
 import { describe, expect, it } from "@jest/globals";
 
 var token =
@@ -6,14 +6,14 @@ var token =
 
 describe("jwt-decode", function () {
   it("should return default and custom claims", function () {
-    var decoded = jwt_decode<JwtPayload & { foo: string }>(token);
+    var decoded = jwtDecode<JwtPayload & { foo: string }>(token);
     expect(decoded.exp).toEqual(1393286893);
     expect(decoded.iat).toEqual(1393268893);
     expect(decoded.foo).toEqual("bar");
   });
 
   it("should return header information", function () {
-    var decoded = jwt_decode(token, { header: true });
+    var decoded = jwtDecode(token, { header: true });
     expect(decoded.typ).toEqual("JWT");
     expect(decoded.alg).toEqual("HS256");
   });
@@ -21,49 +21,49 @@ describe("jwt-decode", function () {
   it("should work with utf8 tokens", function () {
     var utf8_token =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9zw6kiLCJpYXQiOjE0MjU2NDQ5NjZ9.1CfFtdGUPs6q8kT3OGQSVlhEMdbuX0HfNSqum0023a0";
-    var decoded = jwt_decode<JwtPayload & { name: string }>(utf8_token);
+    var decoded = jwtDecode<JwtPayload & { name: string }>(utf8_token);
     expect(decoded.name).toEqual("José");
   });
 
   it("should work with binary tokens", function () {
     var binary_token =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9z6SIsImlhdCI6MTQyNTY0NDk2Nn0.cpnplCBxiw7Xqz5thkqs4Mo_dymvztnI0CI4BN0d1t8";
-    var decoded = jwt_decode<JwtPayload & { name: string }>(binary_token);
+    var decoded = jwtDecode<JwtPayload & { name: string }>(binary_token);
     expect(decoded.name).toEqual("José");
   });
 
   it("should work with double padding", function () {
     var utf8_token =
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpvc8OpIiwiaWF0IjoxNTE2MjM5MDIyfQ.7A3F5SUH2gbBSYVon5mas_Y-KCrWojorKQg7UKGVEIA";
-    var decoded = jwt_decode<JwtPayload & { name: string }>(utf8_token);
+    var decoded = jwtDecode<JwtPayload & { name: string }>(utf8_token);
     expect(decoded.name).toEqual("José");
   });
 
   it("should work with single padding", function () {
     var utf8_token =
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpvc8OpZSIsImlhdCI6MTUxNjIzOTAyMn0.tbjJzDAylkKSV0_YGR5xBJBlFK01C82nZPLIcA3JX1g";
-    var decoded = jwt_decode<JwtPayload & { name: string }>(utf8_token);
+    var decoded = jwtDecode<JwtPayload & { name: string }>(utf8_token);
     expect(decoded.name).toEqual("Josée");
   });
 
   it("should throw InvalidTokenError on nonstring", function () {
     var bad_token = null;
     expect(function () {
-      jwt_decode(bad_token as any);
+      jwtDecode(bad_token as any);
     }).toThrow(InvalidTokenError);
   });
 
   it("should throw InvalidTokenError on string that is not a token", function () {
     var bad_token = "fubar";
     expect(function () {
-      jwt_decode(bad_token);
+      jwtDecode(bad_token);
     }).toThrow(InvalidTokenError);
   });
 
   it("should throw InvalidTokenErrors when token is null", function () {
     var bad_token = null;
     expect(function () {
-      jwt_decode(bad_token as any, { header: true });
+      jwtDecode(bad_token as any, { header: true });
     }).toThrow(
       new InvalidTokenError("Invalid token specified: must be a string")
     );
@@ -72,28 +72,28 @@ describe("jwt-decode", function () {
   it("should throw InvalidTokenErrors when missing part #1", function () {
     var bad_token = ".FAKE_TOKEN";
     expect(function () {
-      jwt_decode(bad_token, { header: true });
+      jwtDecode(bad_token, { header: true });
     }).toThrow(/Invalid token specified: invalid json for part #1/);
   });
 
   it("should throw InvalidTokenErrors when part #1 is not valid base64", function () {
     var bad_token = "TOKEN";
     expect(function () {
-      jwt_decode(bad_token, { header: true });
+      jwtDecode(bad_token, { header: true });
     }).toThrow(/Invalid token specified: invalid base64 for part #1/);
   });
 
   it("should throw InvalidTokenErrors when part #1 is not valid JSON", function () {
     var bad_token = "FAKE.TOKEN";
     expect(function () {
-      jwt_decode(bad_token, { header: true });
+      jwtDecode(bad_token, { header: true });
     }).toThrow(/Invalid token specified: invalid json for part #1/);
   });
 
   it("should throw InvalidTokenErrors when missing part #2", function () {
     var bad_token = "FAKE_TOKEN";
     expect(function () {
-      jwt_decode(bad_token);
+      jwtDecode(bad_token);
     }).toThrow(
       new InvalidTokenError("Invalid token specified: missing part #2")
     );
@@ -102,14 +102,14 @@ describe("jwt-decode", function () {
   it("should throw InvalidTokenErrors when part #2 is not valid base64", function () {
     var bad_token = "FAKE.TOKEN";
     expect(function () {
-      jwt_decode(bad_token);
+      jwtDecode(bad_token);
     }).toThrow(/Invalid token specified: invalid base64 for part #2/);
   });
 
   it("should throw InvalidTokenErrors when part #2 is not valid JSON", function () {
     var bad_token = "FAKE.TOKEN2";
     expect(function () {
-      jwt_decode(bad_token);
+      jwtDecode(bad_token);
     }).toThrow(/Invalid token specified: invalid json for part #2/);
   });
 });


### PR DESCRIPTION
Cleans up the Rollup config a little, by:

- Using a variable to store the `input` field, which is now the same everywhere
- Removing `[]` for output and using a single definition
- Removing `name` for outputs that don't need it
- Removing the explicit `exports` option for the output, as the default already matches.