### PR TITLE
Remove options initializer  (BETA)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,7 +25,6 @@ function jwtDecode(
     throw new InvalidTokenError("Invalid token specified: must be a string");
   }
 
-  options = options || {};
   const pos = options.header === true ? 0 : 1;
 
   const part = token.split(".")[pos];


### PR DESCRIPTION
There is no need to have the options initializer, since it will already be initialized by the default parameter in the function should undefined be provided.

This is dead code that never will incur.