### PR TITLE
Explicit type import and exports (BETA)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,8 +1,8 @@
 "use strict";
 
 import base64_url_decode from "./base64_url_decode";
-import { JwtDecodeOptions, JwtHeader, JwtPayload } from "./global";
-export * from './global';
+import type { JwtDecodeOptions, JwtHeader, JwtPayload } from "./global";
+export type { JwtDecodeOptions, JwtHeader, JwtPayload };
 
 export class InvalidTokenError extends Error {
   constructor(message: string) {


### PR DESCRIPTION
Be explicit about that we are importing types only and what we are actually re-exporting.

Using a global `*` export can often be a pitfall in the long run because it assumes everything is export and often one will create some internal types that often were not intended for everyone to be exported also.

It's better to be clear that we are import types, and also what is meant for public consumption and not.