### PR TITLE
Make options optional no default function parameter initializer (BETA)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,7 +22,6 @@ function jwtDecode(token: string, options?: JwtDecodeOptions) {
     throw new InvalidTokenError("Invalid token specified: must be a string");
   }
 
-  // default empty options object when the provided options is either null | undefined
   options = options || {};
   const pos = options.header === true ? 0 : 1;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,8 +12,6 @@ export class InvalidTokenError extends Error {
 
 InvalidTokenError.prototype.name = "InvalidTokenError";
 
-
-const defaultDecodeOptions = 
 function jwtDecode<T = JwtHeader>(
   token: string,
   options: JwtDecodeOptions & { header: true }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,19 +12,19 @@ export class InvalidTokenError extends Error {
 
 InvalidTokenError.prototype.name = "InvalidTokenError";
 
+
+const defaultDecodeOptions = 
 function jwtDecode<T = JwtHeader>(
   token: string,
   options: JwtDecodeOptions & { header: true }
 ): T;
 function jwtDecode<T = JwtPayload>(token: string, options?: JwtDecodeOptions): T;
-function jwtDecode(
-  token: string,
-  options: JwtDecodeOptions = { header: false }
-) {
+function jwtDecode(token: string, options?: JwtDecodeOptions) {
   if (typeof token !== "string") {
     throw new InvalidTokenError("Invalid token specified: must be a string");
   }
 
+  // default empty options object when the provided options is either null | undefined
   options = options || {};
   const pos = options.header === true ? 0 : 1;
 


### PR DESCRIPTION
Rather than have the default parameter with an default initializer should for when the provided value is undefined, it could be better to have it as an optional object. Thereby the initializer statement `options = options || {};` is much clearer.

closes #177 