### PR TITLE
Use a default export for UMD module

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,26 @@ const jwt_decode = require('jwt-decode');
 
 #### Include with a script tag
 
-Copy the file `jwt-decode.js` from the `build/` folder to your project somewhere, then include it like so:
+Copy the file `jwt-decode.js` from the root of the `build/` folder to your project somewhere, then include it like so:
 
 ```html
 <script src="jwt-decode.js"></script>
 ```
-The jwtDecode function is exposed as a property on the global `jwt_decode` property:
+
+Once this script has loaded, the `jwt_decode` function will be exposed as a global:
 
 ```javascript
 const token = "eyJhsw5c";
-const decoded = jwt_decode.jwtDecode(token); 
+const decoded = jwt_decode(token);
+```
+
+Alternatively, if you are using the [Asynchronous Module Definition (AMD) API](https://github.com/amdjs/amdjs-api/blob/master/AMD.md), you can load the same function as follows:
+
+```javascript
+define(["jwt_decode"], (jwtDecode) => {
+  const token = "eyJhsw5c";
+  const decoded = jwtDecode(token);
+});
 ```
 
 ## Feedback

--- a/lib/index.umd.ts
+++ b/lib/index.umd.ts
@@ -1,0 +1,1 @@
+export { jwtDecode as default } from './index';

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -18,7 +18,7 @@ const plugins = [
 const input = "lib/index.ts";
 
 export default defineConfig([{
-    input,
+    input: "lib/index.umd.ts",
     output: {
       name: "jwt_decode",
       file: "build/jwt-decode.js",


### PR DESCRIPTION
Creates an alias for `jwtDecode` as the default export for UMD modules. Since users of the UMD module are very unlikely to migrate this will give them maximum compatibility with previous versions.