### PR TITLE
Remove `'use strict'` from source

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import base64_url_decode from "./base64_url_decode";
 import { JwtDecodeOptions, JwtHeader, JwtPayload } from "./global";
 export * from './global';


### PR DESCRIPTION
Removes the `'use strict'` statement from the source code. This is no longer required as modules are [strict by default](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#strict_mode_for_modules), and Rollup will therefore automatically add `'use strict'` to the CommonJS and UMD bundles.