### PR TITLE
Add missing tslib dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "rollup-plugin-serve": "^2.0.2",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
+        "tslib": "^2.6.1",
         "tsup": "^7.2.0",
         "typescript": "^5.1.6"
       },
@@ -5445,6 +5446,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "dev": true
     },
     "node_modules/tsup": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "rollup-plugin-serve": "^2.0.2",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
+    "tslib": "^2.6.1",
     "tsup": "^7.2.0",
     "typescript": "^5.1.6"
   },


### PR DESCRIPTION
### Description

Add missing tslib dependency to fix:

> [!] (plugin typescript) RollupError: @rollup/plugin-typescript: Could not find module 'tslib', which is required by this plugin. Is it installed?

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
