### PR TITLE
Drop UMD bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,26 +92,16 @@ const { jwtDecode } = require('jwt-decode');
 
 #### Include with a script tag
 
-Copy the file `jwt-decode.js` from the root of the `build/` folder to your project somewhere, then include it like so:
+Copy the file `jwt-decode.js` from the root of the `build/esm` folder to your project somewhere, then include it using `type="module"` on the corresponding script tag.
+Once this script has loaded, the exported `jwtDecode` function will be available:
 
 ```html
-<script src="jwt-decode.js"></script>
-```
-
-Once this script has loaded, the `jwt_decode` function will be exposed as a global:
-
-```javascript
-const token = "eyJhsw5c";
-const decoded = jwt_decode(token);
-```
-
-Alternatively, if you are using the [Asynchronous Module Definition (AMD) API](https://github.com/amdjs/amdjs-api/blob/master/AMD.md), you can load the same function as follows:
-
-```javascript
-define(["jwt_decode"], (jwtDecode) => {
+<script type="module">
+  import { jwtDecode } from "/path/to/jwt-decode.js";
+  
   const token = "eyJhsw5c";
   const decoded = jwtDecode(token);
-});
+</script>
 ```
 
 ## Feedback

--- a/lib/index.umd.ts
+++ b/lib/index.umd.ts
@@ -1,1 +1,0 @@
-export { jwtDecode as default } from "./index.js";

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -14,18 +14,7 @@ const plugins = [
 
 const input = "lib/index.ts";
 
-export default defineConfig([{
-    input: "lib/index.umd.ts",
-    output: {
-      name: "jwt_decode",
-      file: "build/jwt-decode.js",
-      format: "umd",
-      sourcemap: true,
-    },
-    plugins: [
-      tsPlugin,
-    ]
-  },
+export default defineConfig([
   {
     input,
     output: {


### PR DESCRIPTION
### Description

Dropping the UMD bundle and moving to `type="module"` guidance.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
