### PR TITLE
fix default condition should be the last one

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./build/esm/index.js",
-        "types": "./build/esm/index.d.ts"
+        "types": "./build/esm/index.d.ts",
+        "default": "./build/esm/index.js"
       },
       "require": {
-        "default": "./build/cjs/index.js",
-        "types": "./build/cjs/index.d.ts"
+        "types": "./build/cjs/index.d.ts",
+        "default": "./build/cjs/index.js"
       }
     }
   },


### PR DESCRIPTION
### Description

Default should be the last key in the exports, mainly for [webpack](https://github.com/webpack/enhanced-resolve/blob/3a28f47788de794d9da4d1702a3a583d8422cd48/lib/util/entrypoints.js#L472-L476).


### References

https://github.com/auth0/node-auth0/issues/912

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
