### PR TITLE
Use reccomended configurations for `typescript-eslint`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,19 +8,17 @@
   "ignorePatterns": ["**/*.mjs", "**/*.js"],
   "extends": [
     "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-type-checked",
+    "plugin:@typescript-eslint/stylistic-type-checked",
     "plugin:prettier/recommended"
   ],
   "plugins": ["@typescript-eslint", "import"],
   "parserOptions": {
-    "ecmaVersion": 9
+    "ecmaVersion": 9,
+    "project": true
   },
   "rules": {
-    "@typescript-eslint/no-empty-interface": "warn",
-    "@typescript-eslint/no-explicit-any": "off",
     "import/no-default-export": "error",
-    "@typescript-eslint/no-unused-vars": "error",
     "import/extensions": ["error", "always"]
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,8 +24,8 @@ InvalidTokenError.prototype.name = "InvalidTokenError";
 
 function b64DecodeUnicode(str: string) {
   return decodeURIComponent(
-    atob(str).replace(/(.)/g, (match) => {
-      let code = match.charCodeAt(0).toString(16).toUpperCase();
+    atob(str).replace(/(.)/g, (m, p) => {
+      let code = (p as string).charCodeAt(0).toString(16).toUpperCase();
       if (code.length < 2) {
         code = "0" + code;
       }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -61,7 +61,10 @@ export function jwtDecode<T = JwtHeader>(
   options: JwtDecodeOptions & { header: true },
 ): T;
 export function jwtDecode<T = JwtPayload>(token: string, options?: JwtDecodeOptions): T;
-export function jwtDecode(token: string, options?: JwtDecodeOptions) {
+export function jwtDecode<T = JwtHeader | JwtPayload>(
+  token: string,
+  options?: JwtDecodeOptions,
+): T {
   if (typeof token !== "string") {
     throw new InvalidTokenError("Invalid token specified: must be a string");
   }
@@ -85,7 +88,7 @@ export function jwtDecode(token: string, options?: JwtDecodeOptions) {
   }
 
   try {
-    return JSON.parse(decoded) as object;
+    return JSON.parse(decoded) as T;
   } catch (e) {
     throw new InvalidTokenError(
       `Invalid token specified: invalid json for part #${pos + 1} (${(e as Error).message})`,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,8 +24,8 @@ InvalidTokenError.prototype.name = "InvalidTokenError";
 
 function b64DecodeUnicode(str: string) {
   return decodeURIComponent(
-    atob(str).replace(/(.)/g, (m, p) => {
-      let code = p.charCodeAt(0).toString(16).toUpperCase();
+    atob(str).replace(/(.)/g, (match) => {
+      let code = match.charCodeAt(0).toString(16).toUpperCase();
       if (code.length < 2) {
         code = "0" + code;
       }
@@ -78,17 +78,17 @@ export function jwtDecode(token: string, options?: JwtDecodeOptions) {
   let decoded: string;
   try {
     decoded = base64UrlDecode(part);
-  } catch (e: any) {
+  } catch (e) {
     throw new InvalidTokenError(
-      `Invalid token specified: invalid base64 for part #${pos + 1} (${e.message})`,
+      `Invalid token specified: invalid base64 for part #${pos + 1} (${(e as Error).message})`,
     );
   }
 
   try {
-    return JSON.parse(decoded);
-  } catch (e: any) {
+    return JSON.parse(decoded) as object;
+  } catch (e) {
     throw new InvalidTokenError(
-      `Invalid token specified: invalid json for part #${pos + 1} (${e.message})`,
+      `Invalid token specified: invalid json for part #${pos + 1} (${(e as Error).message})`,
     );
   }
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -49,7 +49,7 @@ describe("jwt-decode", () => {
   it("should throw InvalidTokenError on nonstring", () => {
     const badToken = null;
     expect(() => {
-      jwtDecode(badToken as any);
+      jwtDecode(badToken as unknown as string);
     }).toThrow(InvalidTokenError);
   });
 
@@ -63,7 +63,7 @@ describe("jwt-decode", () => {
   it("should throw InvalidTokenErrors when token is null", () => {
     const badToken = null;
     expect(() => {
-      jwtDecode(badToken as any, { header: true });
+      jwtDecode(badToken as unknown as string, { header: true });
     }).toThrow(new InvalidTokenError("Invalid token specified: must be a string"));
   });
 


### PR DESCRIPTION
Changes the ESLint configuration so that the [recommended configuration](https://typescript-eslint.io/linting/configs/#projects-with-type-checking) of `typescript-eslint` for projects with type-checking is extended.