### PR TITLE
Use built-in version of NPM on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Update NPM version
-          command: sudo npm install -g npm@latest
-      - run:
           name: Install dependencies
           command: npm install
       - run:


### PR DESCRIPTION
Changes the CI to use the version of NPM that ships with the Node.js version it uses. This is to prevent compatibility issues with the recently released NPM 10, which is causing [jobs to fail](https://app.circleci.com/pipelines/github/auth0/jwt-decode/179/workflows/04f1e374-0572-4667-be9b-c4e2cd8314d4/jobs/475).