### PR TITLE
Fall back to Jest defaults where possible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
   ],
   "overrides": [
     {
-      "files": ["lib/**", "test/**"],
+      "files": ["lib/**"],
       "rules": {
         "import/no-default-export": "error"
       }

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ lib-cov
 pids
 logs
 results
-test-results
 
 npm-debug.log
 node_modules

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,7 @@ const jestConfig: JestConfigWithTsJest = {
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
+  coverageProvider: "v8",
 };
 
 export default jestConfig;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,11 +5,6 @@ const jestConfig: JestConfigWithTsJest = {
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
-  testMatch: ["**/test/**/*.test.ts", "**/test/tests.ts"],
-  coverageProvider: "v8",
-  coveragePathIgnorePatterns: ["/node_modules/", "./test"],
-  reporters: ["default", ["jest-junit", { outputDirectory: "test-results/jest" }]],
-  coverageReporters: ["lcov", "text", "text-summary"],
 };
 
 export default jestConfig;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,7 @@ const jestConfig: JestConfigWithTsJest = {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
   coverageProvider: "v8",
+  coverageReporters: ["lcov", "text", "text-summary"],
 };
 
 export default jestConfig;

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -1,4 +1,4 @@
-import { jwtDecode, InvalidTokenError, JwtPayload } from "./../lib/index.js";
+import { jwtDecode, InvalidTokenError, JwtPayload } from "./index.js";
 import { describe, expect, it } from "@jest/globals";
 
 const token =

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "husky": "^8.0.3",
         "jest": "^29.6.2",
         "jest-environment-jsdom": "^29.6.2",
-        "jest-junit": "^16.0.0",
         "lint-staged": "^14.0.1",
         "prettier": "^3.0.2",
         "publint": "^0.2.2",
@@ -5992,21 +5991,6 @@
         "fsevents": "^2.3.2"
       }
     },
-    "node_modules/jest-junit": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
-      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
-      "dev": true,
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2",
-        "xml": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "29.6.2",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.2.tgz",
@@ -7224,18 +7208,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
       "dev": true
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -9543,15 +9515,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -9787,12 +9750,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
-      "dev": true
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "husky": "^8.0.3",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.6.2",
-    "jest-junit": "^16.0.0",
     "lint-staged": "^14.0.1",
     "prettier": "^3.0.2",
     "publint": "^0.2.2",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["./lib"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "target": "ES2017",
     "declaration": true


### PR DESCRIPTION
Cleans up the Jest configuration file as much as possible by falling back to the default values where possible and where it makes sense. This PR also removes the `jest-junit` reporter, as it was not being used anywhere.