### PR TITLE
Raise minimum Node.js version to 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ workflows:
       - build:
           matrix:
             parameters:
-              node-version: ["16.20", "18.16", "20.4"]
+              node-version: ["18.16", "20.4"]
       - ship/node-publish:
           publish-command: npm publish --tag beta
           context:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [ 16, 18, 20 ]
+        node: [ 18, 20 ]
 
     name: Build Package (Node ${{ matrix.node }})
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --fix"


### PR DESCRIPTION
Raises the minimum Node.js version to 18, as version 16 will be [end-of-life on September 11th](https://nodejs.org/en/blog/announcements/nodejs16-eol). See the [Node.js release schedule](https://github.com/nodejs/Release#release-schedule) for more information.