### PR TITLE
Keep GitHub Actions dependencies up-to-date with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Adds some configuration for Dependabot so it can keep the GitHub Actions up-to-date.