### PR TITLE
Remove `type` from package file and default to CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "jwt-decode",
   "version": "4.0.0-beta.4",
   "description": "Decode JWT tokens, mostly useful for browser applications.",
-  "type": "module",
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "types": "build/cjs/index.d.ts",
@@ -31,7 +30,7 @@
   "scripts": {
     "dev": "concurrently --kill-others \"npm run build:watch\" \"npm run dev:server\"",
     "dev:server": "browser-sync start --config bs-config.json",
-    "prebuild": "shx rm -rf ./build && shx mkdir -p ./build/cjs && shx echo '{\"type\": \"commonjs\"}'> build/cjs/package.json",
+    "prebuild": "shx rm -rf ./build && shx mkdir -p ./build/esm && shx echo '{\"type\": \"module\"}'> build/esm/package.json",
     "build": "tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json",
     "build:watch": "npm run build -- --watch",
     "lint": "eslint .",


### PR DESCRIPTION
Some older tooling will always assume that the type of a package is always CommonJS as they are not aware of the `type` field, whereas some more modern tooling might take `"type": "module"` and assume the entry-point linked from `main` is written in ESM, which it is not.

To prevent possible compatibility issues, this PR removes the `type` field entirely, so that things remain as backwards compatible as possible. Then in order to support ESM, it is opt-ed into locally by placing a package file with `"type": "module"`