### PR TITLE
Update lockfile to match supported Node.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
Missed this in #209 as I forgot to run `npm install`, but the lockfile should also have been updated.