### PR TITLE
Add registry-url to actions/setup-node

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 18
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
### Description

- Added registry-url to setup-node as that's required in order for the `NODE_AUTH_TOKEN` to be used, see 
  - https://github.com/actions/setup-node/blob/main/src/main.ts#L59-L61
  - https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
