### PR TITLE
Release v4.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,6 @@ jobs:
         run: npm run build
 
       - name: Publish release to NPM
-        run: npm publish --tag beta
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change log
 
+## Version [4.0.0](https://github.com/auth0/jwt-decode/releases/tag/v4.0.0)
+
+[Full Changelog](https://github.com/auth0/jwt-decode/compare/v3.1.2..v4.0.0)
+
+A new version of the library, including a couple of improvements:
+
+- No longer include a polyfill for [atob](https://developer.mozilla.org/en-US/docs/Web/API/atob), as this is [supported in all major browsers](https://caniuse.com/?search=atob) (and [node environments > 14](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility)).
+- Compile to ES2017, dropping support for anything that does not support ES2017 (which should be very limited [according to caniuse](https://caniuse.com/?search=es2017))
+- Use Node's atob when running on node.
+- Drop support for Node 14 and 16, add support for Node 20.
+- Add support for package.json's `exports` field, for better CJS/ESM support
+- Reorganize build artifacts for better CJS/ESM support (cjs and esm needs to be their own directory with a cjs specific package.json file)
+- Drop manual UMD bundle creation in `index.standalone.ts`, but rely on rollup instead.
+- Infer JwtPayload and JwtHeader default types from the `header` argument by using overloads.
+
+**Additionally, this PR ensures the file size is decreased:**
+
+- **ESM and CJS decreased by 22%**
+- **UMD decreased by 37%**
+
+Even though some users might experience breaking changes, mostly because of the `exports` field, the majority should be able to update without making any changes, assuming the SDK is used in environments with support for `atob`.
+
 ## Version [4.0.0-beta.4](https://github.com/auth0/jwt-decode/releases/tag/v4.0.0-beta.4)
 
 [Full Changelog](https://github.com/auth0/jwt-decode/compare/v4.0.0-beta.3..v4.0.0-beta.4)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jwt-decode",
-  "version": "4.0.0-beta.4",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jwt-decode",
-      "version": "4.0.0-beta.4",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.23.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-decode",
-  "version": "4.0.0-beta.4",
+  "version": "4.0.0",
   "description": "Decode JWT tokens, mostly useful for browser applications.",
   "type": "module",
   "main": "build/cjs/index.js",


### PR DESCRIPTION
A new version of the library, including a couple of improvements:

- No longer include a polyfill for [atob](https://developer.mozilla.org/en-US/docs/Web/API/atob), as this is [supported in all major browsers](https://caniuse.com/?search=atob) (and [node environments > 14](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility)).
- Compile to ES2017, dropping support for anything that does not support ES2017 (which should be very limited [according to caniuse](https://caniuse.com/?search=es2017))
- Use Node's atob when running on node.
- Drop support for Node 14 and 16, add support for Node 20.
- Add support for package.json's `exports` field, for better CJS/ESM support
- Reorganize build artifacts for better CJS/ESM support (cjs and esm needs to be their own directory with a cjs specific package.json file)
- Drop manual UMD bundle creation in `index.standalone.ts`, but rely on rollup instead.
- Infer JwtPayload and JwtHeader default types from the `header` argument by using overloads.

**Additionally, this PR ensures the file size is decreased:**

- **ESM and CJS decreased by 22%**
- **UMD decreased by 37%**

Even though some users might experience breaking changes, mostly because of the `exports` field, the majority should be able to update without making any changes, assuming the SDK is used in environments with support for `atob`.