### PR TITLE
Add README instructions for polyfilling atob

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ console.log(decodedHeader);
 
 This library relies on `atob()`, which is a global function available on [all modern browsers as well as every supported node environment](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility).
 
-In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. [React Native](https://github.com/facebook/hermes/issues/1178)), ensure to provide the corresponding polyfill in your application by using [`base-64`](https://www.npmjs.com/package/base-64):
+In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. [React Native](https://github.com/facebook/hermes/issues/1178)), ensure to provide the corresponding polyfill in your application by using [`core-js/stable/atob`](https://www.npmjs.com/package/core-js):
+
+```js
+import "core-js/stable/atob";
+```
+
+Alternatively, you can also use [`base-64`](https://www.npmjs.com/package/base-64) and polyfill `global.atob` yourself:
 
 ```js
 import { decode } from 'base-64';

--- a/README.md
+++ b/README.md
@@ -57,18 +57,17 @@ console.log(decodedHeader);
 
 This library relies on `atob()`, which is a global function available on [all modern browsers as well as every supported node environment](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility).
 
-In order to use `jwt-decode` in an environment that has no access to `atob()`, ensure to provide the corresponding polyfill in your application:
+In order to use `jwt-decode` in an environment that has no access to `atob()`, ensure to provide the corresponding polyfill in your application by using [`core-js/stable/atob`](https://www.npmjs.com/package/core-js):
 
 ```js
 import "core-js/stable/atob";
 ```
 
-Some environments might not work well with polyfills and require you to import the pure function and expose it yourself instead (e.g. React Native):
+Alternatively, you can also use [`base-64`](https://www.npmjs.com/package/base-64) and polyfill `global.atob` yourself:
 
 ```js
-import atob from "core-js-pure/stable/atob";
-
-global.atob = atob;
+import { decode } from 'base-64';
+global.atob = decode;
 ```
 
 ## Errors

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import "core-js/stable/atob";
 Alternatively, you can also use [`base-64`](https://www.npmjs.com/package/base-64) and polyfill `global.atob` yourself:
 
 ```js
-import { decode } from 'base-64';
+import { decode } from "base-64";
 global.atob = decode;
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,7 @@ console.log(decodedHeader);
 
 This library relies on `atob()`, which is a global function available on [all modern browsers as well as every supported node environment](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility).
 
-In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. [React Native](https://github.com/facebook/hermes/issues/1178)), ensure to provide the corresponding polyfill in your application by using [`core-js/stable/atob`](https://www.npmjs.com/package/core-js):
-
-```js
-import "core-js/stable/atob";
-```
-
-Alternatively, you can also use [`base-64`](https://www.npmjs.com/package/base-64) and polyfill `global.atob` yourself:
+In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. [React Native](https://github.com/facebook/hermes/issues/1178)), ensure to provide the corresponding polyfill in your application by using [`base-64`](https://www.npmjs.com/package/base-64):
 
 ```js
 import { decode } from 'base-64';

--- a/README.md
+++ b/README.md
@@ -57,14 +57,18 @@ console.log(decodedHeader);
 
 This library relies on `atob()`, which is a global function available on [all modern browsers as well as every supported node environment](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility).
 
-In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. React Native), ensure to provide the corresponding polyfill in your application:
+In order to use `jwt-decode` in an environment that has no access to `atob()`, ensure to provide the corresponding polyfill in your application:
 
 ```js
 import "core-js/stable/atob";
-import { jwtDecode } from "jwt-decode";
+```
 
-const token = "eyJ0eXAiO.../// jwt token";
-const decoded = jwtDecode(token);
+Some environments might not work well with polyfills and require you to import the pure function and expose it yourself instead (e.g. React Native):
+
+```
+import atob from "core-js-pure/stable/atob";
+
+global.atob = atob;
 ```
 
 ## Errors

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ console.log(decodedHeader);
 
 This library relies on `atob()`, which is a global function available on [all modern browsers as well as every supported node environment](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility).
 
-In order to use `jwt-decode` in an environment that has no access to `atob()`, ensure to provide the corresponding polyfill in your application by using [`core-js/stable/atob`](https://www.npmjs.com/package/core-js):
+In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. [React Native](https://github.com/facebook/hermes/issues/1178)), ensure to provide the corresponding polyfill in your application by using [`core-js/stable/atob`](https://www.npmjs.com/package/core-js):
 
 ```js
 import "core-js/stable/atob";

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ console.log(decodedHeader);
 
 **Note:** A falsy or malformed token will throw an `InvalidTokenError` error; see below for more information on specific errors.
 
+## Polyfilling atob
+
+This library relies on `atob()`, which is a global function available on [all modern browsers as well as every supported node environment](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility).
+
+In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. React Native), ensure to provide the corresponding polyfill in your application:
+
+```js
+import "core-js/stable/atob";
+import { jwtDecode } from "jwt-decode";
+
+const token = "eyJ0eXAiO.../// jwt token";
+const decoded = jwtDecode(token);
+```
+
 ## Errors
 
 This library works with valid JSON web tokens. The basic format of these token is

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import "core-js/stable/atob";
 
 Some environments might not work well with polyfills and require you to import the pure function and expose it yourself instead (e.g. React Native):
 
-```
+```js
 import atob from "core-js-pure/stable/atob";
 
 global.atob = atob;


### PR DESCRIPTION
### Description

With atob not being available in platforms such as react-native, we are adding readme instructions for polyfilling it.


### References

#241 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
