### PR TITLE
Deprecate CommonJS distribution in favor of ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ const decoded = jwtDecode<JwtPayload>(token); // Returns with the JwtPayload typ
 
 #### Use as a CommonJS package
 
+> [!WARNING]
+> The CommonJS distribution is deprecated, and will be removed some time in the future. To avoid breaking changes it is recommended to use the ESM version instead.
+
 ```javascript
 const { jwtDecode } = require('jwt-decode');
 ...

--- a/deprecate-cjs.js
+++ b/deprecate-cjs.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-undef
+console.warn(
+  "The CommonJS distribution of 'jwt-decode' is deprecated, and will be removed some time in the future. Please use the ESM distribution instead.",
+);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dev:server": "browser-sync start --config bs-config.json",
     "prebuild": "shx rm -rf ./build && shx mkdir -p ./build/cjs && shx echo '{\"type\": \"commonjs\"}'> build/cjs/package.json",
     "build": "tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json",
+    "postbuild": "shx cat ./deprecate-cjs.js >> ./build/cjs/index.js",
     "build:watch": "npm run build -- --watch",
     "lint": "eslint .",
     "lint:package": "publint",


### PR DESCRIPTION
This PR deprecates the CommonJS distribution and recommends to use the ESM version instead. This does not remove the CommonJS functionality, but simply warns users that it might go away in the future, and recommends them to start upgrading.

The reason for this is that the JavaScript ecosystem is slowly moving away from CommonJS to more standard ESM, and many packages have already started to ship as '[ESM only](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)'. This helps prepare users for that coming change, without immediately forcing them to move right away. 