### PR TITLE
Specify react-native version without atob support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ console.log(decodedHeader);
 
 This library relies on `atob()`, which is a global function available on [all modern browsers as well as every supported node environment](https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility).
 
-In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. [React Native](https://github.com/facebook/hermes/issues/1178)), ensure to provide the corresponding polyfill in your application by using [`core-js/stable/atob`](https://www.npmjs.com/package/core-js):
+In order to use `jwt-decode` in an environment that has no access to `atob()` (e.g. [React Native prior to version 0.74](https://github.com/facebook/hermes/issues/1178)), ensure to provide the corresponding polyfill in your application by using [`core-js/stable/atob`](https://www.npmjs.com/package/core-js):
 
 ```js
 import "core-js/stable/atob";


### PR DESCRIPTION
### Description

With [atob](https://github.com/facebook/hermes/commit/13fafde91368553c5ca223b2853c7afe2c377132) and [btoa](https://github.com/facebook/hermes/commit/d2177c31b271e92d1725742605b53d7f6e8acf3e) being available as of react-native 0.74, we no longer need the polyfil.

Closes #398