### PR TITLE
feat: use `Uint8Array.fromBase64` if available

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,6 +35,11 @@ function b64DecodeUnicode(str: string) {
 }
 
 function base64UrlDecode(str: string) {
+  if ("fromBase64" in Uint8Array && typeof Uint8Array.fromBase64 === "function") {
+    const bytes = Uint8Array.fromBase64(str, { alphabet: "base64url" }) as Uint8Array;
+    return new TextDecoder().decode(bytes);
+  }
+
   let output = str.replace(/-/g, "+").replace(/_/g, "/");
   switch (output.length % 4) {
     case 0:


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Use [`Uint8Array.fromBase64`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64) if available in `b64DecodeUnicode` function.

### References

Resolves #395.

### Testing

Test not viable for now because `Uint8Array.fromBase64` is not available in Node.js

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
