### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build package
         run: npm run build


### PR DESCRIPTION
This would avoid malicious scripts in vulnerable packages to be executed on CI